### PR TITLE
Make year filtering strict for dated views

### DIFF
--- a/main.js
+++ b/main.js
@@ -157,7 +157,7 @@ function initSearchAndFilters() {
             const tags = (item.getAttribute('data-tags') || '').split(' ');
             const year = item.getAttribute('data-year') || '';
             const tagMatch = !item.classList.contains('app-card') || activeTag === 'all' || tags.includes(activeTag);
-            const yearMatch = !year || activeYear === 'all' || year === activeYear;
+            const yearMatch = activeYear === 'all' || year === activeYear;
             const match = (!q || text.includes(q)) && tagMatch && yearMatch;
             item.style.display = match ? '' : 'none';
             if (match) count++;


### PR DESCRIPTION
Closes #13

## What changed
- Treat undated filterable items as non-matches when a specific year is selected.
- Preserve the complete view when `All` is selected.
- Reuse the existing section hiding logic so sections with no matching items disappear cleanly.

## Why
The previous condition allowed undated app cards to remain visible for every year. That made year-specific Engineering views misleading for recruiters and other visitors trying to isolate work from a particular year.

## Scope
One filtering condition in `main.js`; no visual changes, dependencies, or unrelated behavior changes.