### PR TITLE
Validate app repository mappings before merge

### DIFF
--- a/.github/workflows/tab-maintenance-check.yml
+++ b/.github/workflows/tab-maintenance-check.yml
@@ -28,7 +28,8 @@ jobs:
             scripts/maintain_filter_accessibility.py \
             scripts/maintain_storage_resilience.py \
             scripts/maintain_external_links.py \
-            scripts/maintain_asset_versions.py; do
+            scripts/maintain_asset_versions.py \
+            scripts/check_app_repo_links.py; do
             python -m py_compile "$script"
           done
       - name: Validate maintenance state and idempotence
@@ -68,6 +69,8 @@ jobs:
             diff -u "$first_diff" "$second_diff" || true
             exit 1
           fi
+      - name: Validate app repository mappings
+        run: python scripts/check_app_repo_links.py
       - name: Validate local tab deep links
         run: |
           python - <<'PY'

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ for script in \
   scripts/maintain_asset_versions.py; do
   python3 "$script"
 done
+python3 scripts/check_app_repo_links.py
 git diff --exit-code -- index.html 404.html main.js effects.js style.css
 ```
 

--- a/scripts/check_app_repo_links.py
+++ b/scripts/check_app_repo_links.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+INDEX = Path("index.html")
+EXPECTED_REPOS = {
+    "おつりDoctor (iOS)": "otsuri_docter",
+    "MAIORAL (iOS)": "PresentMemo",
+}
+REPO_LINK = re.compile(
+    r'href="https://github\.com/sakai1250/([A-Za-z0-9_.-]+)">GitHub</a>'
+)
+
+
+def app_card(text: str, title: str) -> str:
+    marker = f">{title}</a>"
+    start = text.find(marker)
+    if start == -1:
+        raise SystemExit(f"Could not find app title: {title}")
+
+    next_card = text.find('<div class="app-card"', start + len(marker))
+    end = next_card if next_card != -1 else len(text)
+    return text[start:end]
+
+
+def main() -> None:
+    text = INDEX.read_text(encoding="utf-8")
+    problems = []
+
+    for title, expected_repo in EXPECTED_REPOS.items():
+        links = REPO_LINK.findall(app_card(text, title))
+        if links != [expected_repo]:
+            problems.append(
+                f"{title}: expected exactly one GitHub link to {expected_repo}, found {links or 'none'}"
+            )
+
+    if problems:
+        raise SystemExit("\n".join(problems))
+
+    print("OK: app repository links match their products")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_app_repo_links.py
+++ b/scripts/check_app_repo_links.py
@@ -12,15 +12,20 @@ EXPECTED_REPOS = {
 REPO_LINK = re.compile(
     r'href="https://github\.com/sakai1250/([A-Za-z0-9_.-]+)">GitHub</a>'
 )
+APP_CARD_MARKER = '<div class="app-card"'
 
 
 def app_card(text: str, title: str) -> str:
-    marker = f">{title}</a>"
-    start = text.find(marker)
-    if start == -1:
+    title_marker = f">{title}</a>"
+    title_pos = text.find(title_marker)
+    if title_pos == -1:
         raise SystemExit(f"Could not find app title: {title}")
 
-    next_card = text.find('<div class="app-card"', start + len(marker))
+    start = text.rfind(APP_CARD_MARKER, 0, title_pos)
+    if start == -1:
+        raise SystemExit(f"Could not find app card for: {title}")
+
+    next_card = text.find(APP_CARD_MARKER, title_pos + len(title_marker))
     end = next_card if next_card != -1 else len(text)
     return text[start:end]
 


### PR DESCRIPTION
Closes #19.

## What changed
- add a dependency-free validator for the two app-to-repository mappings that have previously been swapped
- run the validator in the existing Interaction maintenance check for pull requests and `main`
- include the same check in README local validation

## Why
The optimize workflow can repair these mappings after merge, but that is too late for review. This makes a wrong product-to-GitHub link fail before merge, which keeps app navigation trustworthy for recruiters and engineers without changing the visible page.