### PR TITLE
Publish security contact and handle LinkedIn bot blocking

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -87,6 +87,7 @@ jobs:
               status = None
               error = None
               success = False
+              host = (urlsplit(url).hostname or '').lower()
 
               for method in ('HEAD', 'GET'):
                   for attempt in range(2):
@@ -106,7 +107,9 @@ jobs:
                           error = str(exc)
 
                           # These responses usually mean the page exists but rejects automation.
-                          if status in (401, 403, 429):
+                          if status in (401, 403, 429) or (
+                              status == 999 and (host == 'linkedin.com' or host.endswith('.linkedin.com'))
+                          ):
                               error = None
                               success = True
                               break

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: '.'
+          include-hidden-files: true
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5


### PR DESCRIPTION
## Summary

- include hidden files in the GitHub Pages artifact so `.well-known/security.txt` is actually deployed
- treat LinkedIn-specific HTTP 999 responses as automation blocking rather than a broken-link signal
- keep deterministic 404/410 responses failing the external-link check

## Why

The current deployment excludes `.well-known/` despite tracking the security contact file in the repository. The link checker also treats LinkedIn's nonstandard anti-bot 999 response as a broken public profile.

This partially addresses #21. The stale Kaggle URL remains tracked there because no verified replacement profile was found; it should be removed or replaced separately rather than guessed.
