### PR TITLE
Guard Pages deployment essentials

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,6 +34,18 @@ jobs:
           persist-credentials: false
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - name: Validate deployable portfolio essentials
+        run: |
+          for path in \
+            index.html \
+            404.html \
+            assets/cv.pdf \
+            .well-known/security.txt; do
+            if [[ ! -s "$path" ]]; then
+              echo "Missing or empty deploy-critical file: $path" >&2
+              exit 1
+            fi
+          done
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:


### PR DESCRIPTION
## Summary

Add a minimal pre-upload guard to the GitHub Pages workflow so it refuses to publish a state missing any deploy-critical portfolio file.

The check requires non-empty:

- `index.html`
- `404.html`
- `assets/cv.pdf`
- `.well-known/security.txt`

This preserves the existing policy of deploying even when optimization fails for transient reasons, while preventing that resilience path from publishing an obviously incomplete portfolio.

No visual behavior or runtime dependency changes.

Closes #30