### PR TITLE
Verify the deployed security contact after Pages publishes

### DIFF
--- a/.github/workflows/security-contact-check.yml
+++ b/.github/workflows/security-contact-check.yml
@@ -85,3 +85,16 @@ jobs:
 
           print(f'OK: security.txt valid through {expires.isoformat()}')
           PY
+      - name: Verify deployed security contact
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          url='https://sakai1250.github.io/.well-known/security.txt'
+          curl --fail --silent --show-error --location \
+            --retry 3 --retry-delay 5 --retry-all-errors --max-time 20 \
+            "$url" --output deployed-security.txt
+          cmp --silent .well-known/security.txt deployed-security.txt || {
+            echo 'Deployed security.txt does not match the repository copy.'
+            diff -u .well-known/security.txt deployed-security.txt || true
+            exit 1
+          }
+          echo 'OK: deployed security.txt is reachable and matches main'

--- a/.github/workflows/security-contact-check.yml
+++ b/.github/workflows/security-contact-check.yml
@@ -12,6 +12,9 @@ on:
       - '.well-known/security.txt'
       - 'SECURITY.md'
       - '.github/workflows/security-contact-check.yml'
+  workflow_run:
+    workflows: ['Deploy static content to Pages']
+    types: [completed]
   schedule:
     - cron: '17 0 * * 1'
   workflow_dispatch:
@@ -86,7 +89,10 @@ jobs:
           print(f'OK: security.txt valid through {expires.isoformat()}')
           PY
       - name: Verify deployed security contact
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: >-
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
         run: |
           url='https://sakai1250.github.io/.well-known/security.txt'
           curl --fail --silent --show-error --location \


### PR DESCRIPTION
## What changed

- Run the existing security contact workflow after `Deploy static content to Pages` completes.
- On successful Pages deployments, scheduled runs, and manual runs, fetch the public canonical `security.txt` URL.
- Require the deployed file to return successfully and exactly match the repository copy.
- Keep pull-request and ordinary push validation local, so deployment timing cannot create false 404 failures.

## Why

Issue #21 is down to one unresolved question: whether `.well-known/security.txt` is actually reachable after deployment. The repository and Pages artifact can both be correct while the public endpoint is still wrong. This adds a check at the point where the answer is meaningful: after Pages finishes publishing.

This improves deployment reliability without changing the portfolio UI.

Related to #21.