### PR TITLE
Keep resource link names accessible without JavaScript

### DIFF
--- a/.github/workflows/resource-link-accessibility.yml
+++ b/.github/workflows/resource-link-accessibility.yml
@@ -1,0 +1,49 @@
+name: Static resource link accessibility
+
+on:
+  pull_request:
+    paths:
+      - 'index.html'
+      - 'effects.js'
+      - 'scripts/maintain_resource_link_accessibility.py'
+      - '.github/workflows/resource-link-accessibility.yml'
+  workflow_run:
+    workflows: ['Optimize Portfolio Assets']
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: static-resource-link-accessibility
+  cancel-in-progress: true
+
+jobs:
+  maintain:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout portfolio
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
+
+      - name: Generate static accessible resource names
+        run: |
+          python3 scripts/maintain_resource_link_accessibility.py
+          cp index.html /tmp/index-after-first-run.html
+          python3 scripts/maintain_resource_link_accessibility.py
+          cmp /tmp/index-after-first-run.html index.html
+          git diff --check
+
+      - name: Commit generated HTML
+        if: github.event_name != 'pull_request'
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+        with:
+          commit_message: 'Keep resource link accessibility in static HTML'
+          file_pattern: 'index.html'
+          commit_user_name: 'sakai1250'
+          commit_user_email: '92532910+sakai1250@users.noreply.github.com'
+          commit_author: 'sakai1250 <92532910+sakai1250@users.noreply.github.com>'

--- a/scripts/maintain_filter_accessibility.py
+++ b/scripts/maintain_filter_accessibility.py
@@ -29,21 +29,24 @@ tab_year_sync = """    const yearFilterRow = document.querySelector('.year-filte
         });
     };
 """
+expected_generated_init = base_init + "\n" + pressed_init + "\n" + tab_year_sync
 
 if base_init not in text:
     raise SystemExit("Could not find filter initialization block")
 
-# Normalize the generated blocks instead of repeatedly inserting after prefixes
-# that remain present inside the generated output.
-text = text.replace("\n" + pressed_init, "")
-text = re.sub(
-    r"\n    const yearFilterRow = document\.querySelector\('\.year-filter'\);\n"
-    r"    const syncYearFilterForTab = \(activeContent\) => \{[\s\S]*?\n    \};\n",
-    "\n",
-    text,
-    count=1,
-)
-text = text.replace(base_init, base_init + "\n" + pressed_init + "\n" + tab_year_sync, 1)
+# Do not rewrite an already-correct generated block. Repeatedly deleting and
+# reinserting it leaves surrounding blank lines behind, which makes every
+# maintenance pass change main.js even though behavior is already correct.
+if expected_generated_init not in text:
+    text = text.replace("\n" + pressed_init, "")
+    text = re.sub(
+        r"\n    const yearFilterRow = document\.querySelector\('\.year-filter'\);\n"
+        r"    const syncYearFilterForTab = \(activeContent\) => \{[\s\S]*?\n    \};\n",
+        "\n",
+        text,
+        count=1,
+    )
+    text = text.replace(base_init, expected_generated_init, 1)
 
 old_apply_head = """    const apply = () => {
         const q = input ? input.value.toLowerCase().trim() : '';

--- a/scripts/maintain_resource_link_accessibility.py
+++ b/scripts/maintain_resource_link_accessibility.py
@@ -5,6 +5,7 @@ import re
 
 INDEX = Path("index.html")
 PUBLICATION_LINKS = {"[Paper]", "[Program]"}
+APP_CARD_MARKER = '<div class="app-card"'
 
 
 def normalize_text(value: str) -> str:
@@ -62,29 +63,34 @@ def update_publication_links(text: str) -> tuple[str, int]:
 
 
 def update_app_links(text: str) -> tuple[str, int]:
-    card_pattern = re.compile(
-        r'(<div class="app-card"\b[\s\S]*?)(?=\n\s*<div class="app-card"\b|\n\s*</div>\n\s*</section>)'
-    )
     links_pattern = re.compile(
         r'(<div class="app-links">)([\s\S]*?)(</div>)'
     )
     anchor_pattern = re.compile(r'<a\b[^>]*>[\s\S]*?</a>')
-    updated_count = 0
+    parts = text.split(APP_CARD_MARKER)
+    if len(parts) == 1:
+        return text, 0
 
-    def update_card(match: re.Match[str]) -> str:
-        nonlocal updated_count
-        card = match.group(1)
+    updated_count = 0
+    updated_parts = [parts[0]]
+
+    for remainder in parts[1:]:
+        card = APP_CARD_MARKER + remainder
         title_match = re.search(
             r'<a\b[^>]*class="app-title"[^>]*>([\s\S]*?)</a>',
             card,
         )
         if not title_match:
-            return card
+            updated_parts.append(card)
+            continue
+
         title = normalize_text(title_match.group(1))
         if not title:
-            return card
+            updated_parts.append(card)
+            continue
 
         def update_links(links_match: re.Match[str]) -> str:
+            nonlocal updated_count
             prefix, links, suffix = links_match.groups()
 
             def update_anchor(anchor_match: re.Match[str]) -> str:
@@ -98,9 +104,9 @@ def update_app_links(text: str) -> tuple[str, int]:
 
             return prefix + anchor_pattern.sub(update_anchor, links) + suffix
 
-        return links_pattern.sub(update_links, card, count=1)
+        updated_parts.append(links_pattern.sub(update_links, card, count=1))
 
-    return card_pattern.sub(update_card, text), updated_count
+    return "".join(updated_parts), updated_count
 
 
 def main() -> None:

--- a/scripts/maintain_resource_link_accessibility.py
+++ b/scripts/maintain_resource_link_accessibility.py
@@ -1,0 +1,124 @@
+from html import escape
+from pathlib import Path
+import re
+
+
+INDEX = Path("index.html")
+PUBLICATION_LINKS = {"[Paper]", "[Program]"}
+
+
+def normalize_text(value: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", value)).strip()
+
+
+def set_aria_label(anchor: str, label: str) -> str:
+    escaped = escape(label, quote=True)
+    opening_end = anchor.find(">")
+    if opening_end == -1:
+        return anchor
+
+    opening = anchor[:opening_end]
+    body = anchor[opening_end:]
+    if re.search(r'\saria-label="[^"]*"', opening):
+        opening = re.sub(
+            r'\saria-label="[^"]*"',
+            f' aria-label="{escaped}"',
+            opening,
+            count=1,
+        )
+    else:
+        opening += f' aria-label="{escaped}"'
+    return opening + body
+
+
+def update_publication_links(text: str) -> tuple[str, int]:
+    item_pattern = re.compile(r'<li\b[^>]*data-year="[^"]+"[^>]*>[\s\S]*?</li>')
+    anchor_pattern = re.compile(r'<a\b[^>]*>[\s\S]*?</a>')
+    updated_count = 0
+
+    def update_item(match: re.Match[str]) -> str:
+        nonlocal updated_count
+        item = match.group(0)
+        title_match = re.search(r'“\s*([^”]+?)\s*”', item)
+        if not title_match:
+            return item
+        title = normalize_text(title_match.group(1))
+        if not title:
+            return item
+
+        def update_anchor(anchor_match: re.Match[str]) -> str:
+            nonlocal updated_count
+            anchor = anchor_match.group(0)
+            label = normalize_text(anchor)
+            if label not in PUBLICATION_LINKS:
+                return anchor
+            resource = label.strip("[]")
+            updated_count += 1
+            return set_aria_label(anchor, f"{resource}: {title}")
+
+        return anchor_pattern.sub(update_anchor, item)
+
+    return item_pattern.sub(update_item, text), updated_count
+
+
+def update_app_links(text: str) -> tuple[str, int]:
+    card_pattern = re.compile(
+        r'(<div class="app-card"\b[\s\S]*?)(?=\n\s*<div class="app-card"\b|\n\s*</div>\n\s*</section>)'
+    )
+    links_pattern = re.compile(
+        r'(<div class="app-links">)([\s\S]*?)(</div>)'
+    )
+    anchor_pattern = re.compile(r'<a\b[^>]*>[\s\S]*?</a>')
+    updated_count = 0
+
+    def update_card(match: re.Match[str]) -> str:
+        nonlocal updated_count
+        card = match.group(1)
+        title_match = re.search(
+            r'<a\b[^>]*class="app-title"[^>]*>([\s\S]*?)</a>',
+            card,
+        )
+        if not title_match:
+            return card
+        title = normalize_text(title_match.group(1))
+        if not title:
+            return card
+
+        def update_links(links_match: re.Match[str]) -> str:
+            prefix, links, suffix = links_match.groups()
+
+            def update_anchor(anchor_match: re.Match[str]) -> str:
+                nonlocal updated_count
+                anchor = anchor_match.group(0)
+                resource = normalize_text(anchor)
+                if not resource:
+                    return anchor
+                updated_count += 1
+                return set_aria_label(anchor, f"{resource}: {title}")
+
+            return prefix + anchor_pattern.sub(update_anchor, links) + suffix
+
+        return links_pattern.sub(update_links, card, count=1)
+
+    return card_pattern.sub(update_card, text), updated_count
+
+
+def main() -> None:
+    text = INDEX.read_text(encoding="utf-8")
+    text, publication_count = update_publication_links(text)
+    text, app_count = update_app_links(text)
+
+    if publication_count == 0:
+        raise SystemExit("No publication resource links were found")
+    if app_count == 0:
+        raise SystemExit("No app resource links were found")
+
+    INDEX.write_text(text, encoding="utf-8")
+    print(
+        f"Kept contextual accessible names on {publication_count} publication links "
+        f"and {app_count} app resource links"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #38

## What changed

- Add an idempotent maintenance script that writes contextual `aria-label` values into static publication and app resource links.
- Cover repeated `[Paper]` / `[Program]`, `GitHub`, `App Store`, Web, and platform links without changing visible text or layout.
- Run the transform in pull requests for validation and after `Optimize Portfolio Assets` on `main`, then commit only the generated `index.html` when needed.
- Verify a second transform run produces identical HTML.
- Fix the existing year-filter maintenance transform so an already-correct block is not deleted and reinserted on every run, which had been accumulating blank lines in `main.js` and causing unrelated PR maintenance failures.

## Why

The same contextual labels currently exist only after `effects.js` runs. If JavaScript is disabled or fails, screen-reader users fall back to repeated generic link names even though the rest of the portfolio remains available. Static labels keep the accessibility behavior aligned with the site's no-JavaScript resilience goal.

The PR validation also exposed a pre-existing idempotence defect in filter maintenance. Fixing it keeps future maintenance checks stable instead of producing whitespace-only drift.