### PR TITLE
Keep table-of-contents disclosure state accessible

### DIFF
--- a/main.js
+++ b/main.js
@@ -342,8 +342,16 @@ function initResearchPriority() {
 function initTOC() {
     const fab = document.getElementById('toc-fab'), menu = document.getElementById('toc-menu');
     if (fab && menu) {
-        fab.addEventListener('click', () => menu.classList.toggle('show'));
-        document.addEventListener('click', (e) => { if (!menu.contains(e.target) && !fab.contains(e.target)) menu.classList.remove('show'); });
+        const setOpen = (open) => {
+            menu.classList.toggle('show', open);
+            fab.setAttribute('aria-expanded', String(open));
+        };
+        fab.setAttribute('aria-controls', 'toc-menu');
+        setOpen(menu.classList.contains('show'));
+        fab.addEventListener('click', () => setOpen(!menu.classList.contains('show')));
+        document.addEventListener('click', (e) => {
+            if (!menu.contains(e.target) && !fab.contains(e.target)) setOpen(false);
+        });
         updateTOC();
         updateSectionTabs();
     }
@@ -370,6 +378,7 @@ function updateTOC() {
             const h = document.querySelector('.header-bar').offsetHeight;
             window.scrollTo({ top: s.getBoundingClientRect().top + window.scrollY - h - 20, behavior: 'smooth' });
             document.getElementById('toc-menu').classList.remove('show');
+            document.getElementById('toc-fab')?.setAttribute('aria-expanded', 'false');
         });
         nav.appendChild(a);
     });

--- a/scripts/maintain_tabs.py
+++ b/scripts/maintain_tabs.py
@@ -242,10 +242,11 @@ elif accessible_toc not in js:
 old_toc_link_close = "            document.getElementById('toc-menu').classList.remove('show');"
 new_toc_link_close = """            document.getElementById('toc-menu').classList.remove('show');
             document.getElementById('toc-fab')?.setAttribute('aria-expanded', 'false');"""
-if old_toc_link_close in js:
-    js = js.replace(old_toc_link_close, new_toc_link_close, 1)
-elif new_toc_link_close not in js:
-    raise SystemExit("Could not find expected TOC link close behavior")
+if new_toc_link_close not in js:
+    if old_toc_link_close in js:
+        js = js.replace(old_toc_link_close, new_toc_link_close, 1)
+    else:
+        raise SystemExit("Could not find expected TOC link close behavior")
 
 js_path.write_text(js, encoding="utf-8")
 

--- a/scripts/maintain_tabs.py
+++ b/scripts/maintain_tabs.py
@@ -203,9 +203,9 @@ elif accessible_modal in js:
 elif focus_trapped_modal not in js:
     raise SystemExit("Could not find expected app modal behavior")
 
-# The floating table of contents is a disclosure control. Keep its expanded
-# state synchronized for screen readers whenever pointer or keyboard actions
-# open or close the menu.
+# The floating table of contents becomes an interactive disclosure only after
+# JavaScript initializes it. Expose its controlled element and expanded state at
+# that same point, then keep the state synchronized for every close path.
 old_toc = """function initTOC() {
     const fab = document.getElementById('toc-fab'), menu = document.getElementById('toc-menu');
     if (fab && menu) {
@@ -293,18 +293,6 @@ for tab_id in ("research", "engineer"):
     attrs = re.sub(r'\s+role="tabpanel"', '', attrs)
     attrs = re.sub(r'\s+aria-labelledby="[^"]+"', '', attrs)
     html = html[:match.start()] + f'<div {attrs}>' + html[match.end():]
-
-# Expose the disclosure relationship before JavaScript runs. Runtime code keeps
-# aria-expanded synchronized with the actual visual state.
-toc_button_plain = '<button id="toc-fab" type="button" aria-label="Table of contents / 目次">'
-toc_button_accessible = (
-    '<button id="toc-fab" type="button" aria-label="Table of contents / 目次" '
-    'aria-controls="toc-menu" aria-expanded="false">'
-)
-if toc_button_plain in html:
-    html = html.replace(toc_button_plain, toc_button_accessible, 1)
-elif toc_button_accessible not in html:
-    raise SystemExit("Could not find expected TOC button markup")
 
 html_path.write_text(html, encoding="utf-8")
 

--- a/scripts/maintain_tabs.py
+++ b/scripts/maintain_tabs.py
@@ -203,6 +203,50 @@ elif accessible_modal in js:
 elif focus_trapped_modal not in js:
     raise SystemExit("Could not find expected app modal behavior")
 
+# The floating table of contents is a disclosure control. Keep its expanded
+# state synchronized for screen readers whenever pointer or keyboard actions
+# open or close the menu.
+old_toc = """function initTOC() {
+    const fab = document.getElementById('toc-fab'), menu = document.getElementById('toc-menu');
+    if (fab && menu) {
+        fab.addEventListener('click', () => menu.classList.toggle('show'));
+        document.addEventListener('click', (e) => { if (!menu.contains(e.target) && !fab.contains(e.target)) menu.classList.remove('show'); });
+        updateTOC();
+        updateSectionTabs();
+    }
+}
+"""
+accessible_toc = """function initTOC() {
+    const fab = document.getElementById('toc-fab'), menu = document.getElementById('toc-menu');
+    if (fab && menu) {
+        const setOpen = (open) => {
+            menu.classList.toggle('show', open);
+            fab.setAttribute('aria-expanded', String(open));
+        };
+        fab.setAttribute('aria-controls', 'toc-menu');
+        setOpen(menu.classList.contains('show'));
+        fab.addEventListener('click', () => setOpen(!menu.classList.contains('show')));
+        document.addEventListener('click', (e) => {
+            if (!menu.contains(e.target) && !fab.contains(e.target)) setOpen(false);
+        });
+        updateTOC();
+        updateSectionTabs();
+    }
+}
+"""
+if old_toc in js:
+    js = js.replace(old_toc, accessible_toc, 1)
+elif accessible_toc not in js:
+    raise SystemExit("Could not find expected TOC disclosure behavior")
+
+old_toc_link_close = "            document.getElementById('toc-menu').classList.remove('show');"
+new_toc_link_close = """            document.getElementById('toc-menu').classList.remove('show');
+            document.getElementById('toc-fab')?.setAttribute('aria-expanded', 'false');"""
+if old_toc_link_close in js:
+    js = js.replace(old_toc_link_close, new_toc_link_close, 1)
+elif new_toc_link_close not in js:
+    raise SystemExit("Could not find expected TOC link close behavior")
+
 js_path.write_text(js, encoding="utf-8")
 
 html_path = Path("index.html")
@@ -249,6 +293,18 @@ for tab_id in ("research", "engineer"):
     attrs = re.sub(r'\s+role="tabpanel"', '', attrs)
     attrs = re.sub(r'\s+aria-labelledby="[^"]+"', '', attrs)
     html = html[:match.start()] + f'<div {attrs}>' + html[match.end():]
+
+# Expose the disclosure relationship before JavaScript runs. Runtime code keeps
+# aria-expanded synchronized with the actual visual state.
+toc_button_plain = '<button id="toc-fab" type="button" aria-label="Table of contents / 目次">'
+toc_button_accessible = (
+    '<button id="toc-fab" type="button" aria-label="Table of contents / 目次" '
+    'aria-controls="toc-menu" aria-expanded="false">'
+)
+if toc_button_plain in html:
+    html = html.replace(toc_button_plain, toc_button_accessible, 1)
+elif toc_button_accessible not in html:
+    raise SystemExit("Could not find expected TOC button markup")
 
 html_path.write_text(html, encoding="utf-8")
 


### PR DESCRIPTION
Closes #40

## What changed
- teaches the existing interaction maintenance step to add `aria-controls="toc-menu"` and an initial `aria-expanded="false"` to the TOC button;
- keeps `aria-expanded` synchronized with visual open/close state;
- resets the state when an outside click or TOC link closes the menu;
- keeps the change idempotent so future maintenance runs preserve it.

## Why
The TOC already works visually, but assistive technology cannot tell whether it is open or which element the button controls. This fixes that without changing layout or adding UI.