### PR TITLE
Initialize saved language before localized content

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     safeInit(initTabs, 'Tabs');
     safeInit(initTheme, 'Theme');
+    safeInit(initLanguage, 'Language');
     safeInit(initModals, 'Modals');
     safeInit(initStats, 'Stats');
     safeInit(initSearchAndFilters, 'SearchAndFilters');
@@ -25,7 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
     safeInit(initContactForm, 'ContactForm');
     safeInit(initStickyHeader, 'StickyHeader');
     safeInit(initReadingProgress, 'ReadingProgress');
-    safeInit(initLanguage, 'Language');
 
     // Visual Effects (From effects.js)
     safeInit(window.initBackgroundParticles, 'BackgroundParticles');


### PR DESCRIPTION
## What changed
- apply the stored language immediately after tab/theme initialization
- run TOC, section navigation, and Qiita article loading only after the saved language is active

## Why
Visitors who previously selected English could otherwise build localized dynamic content while the page was still in the default Japanese state. The clearest failure case was a Qiita fetch error that stayed in Japanese after the saved English preference was restored.

## Scope
This only changes initialization order. It does not change layout, styling, content, or storage behavior.

Closes #42