### PR TITLE
Make app detail dialogs keyboard accessible

### DIFF
--- a/scripts/maintain_tabs.py
+++ b/scripts/maintain_tabs.py
@@ -5,9 +5,6 @@ import re
 js_path = Path("main.js")
 js = js_path.read_text(encoding="utf-8")
 
-# Once JavaScript is running, the Research / Engineering controls become a real
-# tab interface. Keep the ARIA semantics and selected state in the runtime code,
-# where they accurately describe what the page is doing.
 required_runtime_markers = (
     "if (tabNav) tabNav.setAttribute('role', 'tablist');",
     "i.setAttribute('role', 'tab');",
@@ -20,18 +17,6 @@ for marker in required_runtime_markers:
     if marker not in js:
         raise SystemExit(f"Missing runtime tab accessibility marker: {marker}")
 
-# Without JavaScript these controls are ordinary page links. Once JavaScript
-# upgrades them into tabs, prevent the anchor's default jump so switching tabs
-# does not unexpectedly move the viewport, especially on mobile.
-legacy_keyboard = """        const activate = () => switchTab(id, true);
-        i.addEventListener('click', activate);
-        i.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                activate();
-                return;
-            }
-"""
 plain_anchor_click = """        i.addEventListener('click', () => switchTab(id, true));
         i.addEventListener('keydown', (e) => {
 """
@@ -41,29 +26,11 @@ enhanced_anchor_click = """        i.addEventListener('click', (e) => {
         });
         i.addEventListener('keydown', (e) => {
 """
-if legacy_keyboard in js:
-    js = js.replace(legacy_keyboard, enhanced_anchor_click, 1)
-elif plain_anchor_click in js:
+if plain_anchor_click in js:
     js = js.replace(plain_anchor_click, enhanced_anchor_click, 1)
 elif enhanced_anchor_click not in js:
     raise SystemExit("Could not find expected primary tab click handling")
 
-# Follow the standard tab keyboard pattern: arrows move between adjacent tabs,
-# while Home and End jump directly to the first and last tab. With only two
-# primary sections this is small, but it keeps keyboard behavior predictable and
-# remains correct if another primary section is added later.
-old_primary_keyboard = """        i.addEventListener('keydown', (e) => {
-            if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
-            e.preventDefault();
-            const items = Array.from(tabItems);
-            const current = items.indexOf(i);
-            const next = e.key === 'ArrowRight'
-                ? (current + 1) % items.length
-                : (current - 1 + items.length) % items.length;
-            items[next].focus();
-            switchTab(items[next].getAttribute('data-tab'), true);
-        });
-"""
 enhanced_primary_keyboard = """        i.addEventListener('keydown', (e) => {
             const items = Array.from(tabItems);
             const current = items.indexOf(i);
@@ -78,90 +45,21 @@ enhanced_primary_keyboard = """        i.addEventListener('keydown', (e) => {
             switchTab(items[next].getAttribute('data-tab'), true);
         });
 """
-if old_primary_keyboard in js:
-    js = js.replace(old_primary_keyboard, enhanced_primary_keyboard, 1)
-elif enhanced_primary_keyboard not in js:
+if enhanced_primary_keyboard not in js:
     raise SystemExit("Could not find expected primary tab keyboard handling")
 
-old_section_state = "    tabs.forEach((tab, index) => tab.classList.toggle('active', index === activeIndex));"
 new_section_state = """    tabs.forEach((tab, index) => {
         const active = index === activeIndex;
         tab.classList.toggle('active', active);
         if (active) tab.setAttribute('aria-current', 'true');
         else tab.removeAttribute('aria-current');
     });"""
-if old_section_state in js:
+if new_section_state not in js:
+    old_section_state = "    tabs.forEach((tab, index) => tab.classList.toggle('active', index === activeIndex));"
+    if old_section_state not in js:
+        raise SystemExit("Could not find expected section tab state update")
     js = js.replace(old_section_state, new_section_state, 1)
-elif new_section_state not in js:
-    raise SystemExit("Could not find expected section tab state update")
 
-# The app detail overlay must behave like a dialog once JavaScript opens it.
-# Keep its hidden state synchronized for assistive technology, allow Escape to
-# close it, keep keyboard focus inside it, and return focus to the invoking card.
-old_modal = """function initModals() {
-    const modal = document.getElementById('app-modal');
-    if (!modal) return;
-    const img = document.getElementById('modal-img'), title = document.getElementById('modal-title'), desc = document.getElementById('modal-desc'), links = document.getElementById('modal-links');
-    document.querySelectorAll('.app-card').forEach(card => {
-        card.addEventListener('click', (e) => {
-            if (e.target.closest('a')) return;
-            img.src = card.querySelector('.app-thumb').src;
-            title.textContent = card.querySelector('.app-title').textContent;
-            desc.textContent = card.querySelector('.app-desc').textContent;
-            links.innerHTML = card.querySelector('.app-links')?.innerHTML || '';
-            modal.classList.add('open');
-            document.body.style.overflow = 'hidden';
-        });
-    });
-    const close = () => { modal.classList.remove('open'); document.body.style.overflow = ''; };
-    modal.querySelector('.modal-close')?.addEventListener('click', close);
-    modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
-}
-"""
-accessible_modal = """function initModals() {
-    const modal = document.getElementById('app-modal');
-    if (!modal) return;
-    const dialog = modal.querySelector('.modal-container');
-    const img = document.getElementById('modal-img'), title = document.getElementById('modal-title'), desc = document.getElementById('modal-desc'), links = document.getElementById('modal-links');
-    let opener = null;
-
-    modal.setAttribute('role', 'dialog');
-    modal.setAttribute('aria-modal', 'true');
-    modal.setAttribute('aria-labelledby', 'modal-title');
-
-    const close = () => {
-        if (!modal.classList.contains('open')) return;
-        modal.classList.remove('open');
-        modal.setAttribute('aria-hidden', 'true');
-        document.body.style.overflow = '';
-        opener?.focus();
-        opener = null;
-    };
-
-    document.querySelectorAll('.app-card').forEach(card => {
-        card.addEventListener('click', (e) => {
-            if (e.target.closest('a')) return;
-            const thumb = card.querySelector('.app-thumb');
-            const cardTitle = card.querySelector('.app-title');
-            if (!thumb || !cardTitle) return;
-            opener = card;
-            img.src = thumb.src;
-            title.textContent = cardTitle.textContent;
-            desc.textContent = card.querySelector('.app-desc')?.textContent || '';
-            links.innerHTML = card.querySelector('.app-links')?.innerHTML || '';
-            modal.classList.add('open');
-            modal.setAttribute('aria-hidden', 'false');
-            document.body.style.overflow = 'hidden';
-            dialog?.focus();
-        });
-    });
-    modal.querySelector('.modal-close')?.addEventListener('click', close);
-    modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && modal.classList.contains('open')) close();
-    });
-}
-"""
 focus_trapped_modal = """function initModals() {
     const modal = document.getElementById('app-modal');
     if (!modal) return;
@@ -231,26 +129,100 @@ focus_trapped_modal = """function initModals() {
     });
 }
 """
-if old_modal in js:
-    js = js.replace(old_modal, focus_trapped_modal, 1)
-elif accessible_modal in js:
-    js = js.replace(accessible_modal, focus_trapped_modal, 1)
-elif focus_trapped_modal not in js:
-    raise SystemExit("Could not find expected app modal behavior")
 
-# The floating table of contents becomes an interactive disclosure only after
-# JavaScript initializes it. Expose its controlled element and expanded state at
-# that same point, then keep the state synchronized for every close path.
-old_toc = """function initTOC() {
-    const fab = document.getElementById('toc-fab'), menu = document.getElementById('toc-menu');
-    if (fab && menu) {
-        fab.addEventListener('click', () => menu.classList.toggle('show'));
-        document.addEventListener('click', (e) => { if (!menu.contains(e.target) && !fab.contains(e.target)) menu.classList.remove('show'); });
-        updateTOC();
-        updateSectionTabs();
-    }
+keyboard_modal = """function initModals() {
+    const modal = document.getElementById('app-modal');
+    if (!modal) return;
+    const dialog = modal.querySelector('.modal-container');
+    const img = document.getElementById('modal-img'), title = document.getElementById('modal-title'), desc = document.getElementById('modal-desc'), links = document.getElementById('modal-links');
+    let opener = null;
+
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-labelledby', 'modal-title');
+
+    const close = () => {
+        if (!modal.classList.contains('open')) return;
+        modal.classList.remove('open');
+        modal.setAttribute('aria-hidden', 'true');
+        document.body.style.overflow = '';
+        opener?.focus();
+        opener = null;
+    };
+
+    const openModal = (card, trigger) => {
+        const thumb = card.querySelector('.app-thumb');
+        const cardTitle = card.querySelector('.app-title');
+        if (!thumb || !cardTitle) return;
+        opener = trigger;
+        img.src = thumb.src;
+        title.textContent = cardTitle.textContent;
+        desc.textContent = card.querySelector('.app-desc')?.textContent || '';
+        links.innerHTML = card.querySelector('.app-links')?.innerHTML || '';
+        modal.classList.add('open');
+        modal.setAttribute('aria-hidden', 'false');
+        document.body.style.overflow = 'hidden';
+        dialog?.focus();
+    };
+
+    document.querySelectorAll('.app-card').forEach(card => {
+        const appLinks = card.querySelector('.app-links');
+        if (!appLinks) return;
+
+        let trigger = appLinks.querySelector('.app-detail-trigger');
+        if (!trigger) {
+            trigger = document.createElement('button');
+            trigger.type = 'button';
+            trigger.className = 'app-detail-trigger';
+            trigger.innerHTML = '<span lang="ja">詳細</span><span lang="en">Details</span>';
+            appLinks.appendChild(trigger);
+        }
+        trigger.addEventListener('click', (e) => {
+            e.stopPropagation();
+            openModal(card, trigger);
+        });
+        card.addEventListener('click', (e) => {
+            if (e.target.closest('a, button')) return;
+            openModal(card, trigger);
+        });
+    });
+    modal.querySelector('.modal-close')?.addEventListener('click', close);
+    modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+    document.addEventListener('keydown', (e) => {
+        if (!modal.classList.contains('open')) return;
+        if (e.key === 'Escape') {
+            close();
+            return;
+        }
+        if (e.key !== 'Tab') return;
+
+        const focusable = Array.from(modal.querySelectorAll(
+            'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )).filter(el => !el.hasAttribute('hidden') && el.offsetParent !== null);
+        if (!focusable.length) {
+            e.preventDefault();
+            dialog?.focus();
+            return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey && (active === first || active === dialog || !modal.contains(active))) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && (active === last || !modal.contains(active))) {
+            e.preventDefault();
+            first.focus();
+        }
+    });
 }
 """
+if focus_trapped_modal in js:
+    js = js.replace(focus_trapped_modal, keyboard_modal, 1)
+elif keyboard_modal not in js:
+    raise SystemExit("Could not find expected app modal behavior")
+
 accessible_toc = """function initTOC() {
     const fab = document.getElementById('toc-fab'), menu = document.getElementById('toc-menu');
     if (fab && menu) {
@@ -269,64 +241,44 @@ accessible_toc = """function initTOC() {
     }
 }
 """
-if old_toc in js:
-    js = js.replace(old_toc, accessible_toc, 1)
-elif accessible_toc not in js:
+if accessible_toc not in js:
     raise SystemExit("Could not find expected TOC disclosure behavior")
 
 old_toc_link_close = "            document.getElementById('toc-menu').classList.remove('show');"
 new_toc_link_close = """            document.getElementById('toc-menu').classList.remove('show');
             document.getElementById('toc-fab')?.setAttribute('aria-expanded', 'false');"""
 if new_toc_link_close not in js:
-    if old_toc_link_close in js:
-        js = js.replace(old_toc_link_close, new_toc_link_close, 1)
-    else:
+    if old_toc_link_close not in js:
         raise SystemExit("Could not find expected TOC link close behavior")
+    js = js.replace(old_toc_link_close, new_toc_link_close, 1)
 
-# The visible TOC controls intentionally show only the first character of each
-# section. Give assistive technology the full localized section title instead of
-# announcing ambiguous names such as just "R" or "A".
 toc_data_title = "        a.setAttribute('data-title', text);"
 toc_accessible_name = """        a.setAttribute('data-title', text);
         a.setAttribute('aria-label', text);"""
 if toc_accessible_name not in js:
-    if toc_data_title in js:
-        js = js.replace(toc_data_title, toc_accessible_name, 1)
-    else:
+    if toc_data_title not in js:
         raise SystemExit("Could not find expected TOC link label setup")
+    js = js.replace(toc_data_title, toc_accessible_name, 1)
 
 js_path.write_text(js, encoding="utf-8")
 
 html_path = Path("index.html")
 html = html_path.read_text(encoding="utf-8")
-
-# Without JavaScript both primary sections remain visible. Keep these controls as
-# real page links so Research / Engineering navigation still works when scripts
-# fail. Runtime JavaScript adds tab semantics only after it starts hiding inactive
-# panels.
 html = re.sub(
     r'(<nav class="tab-nav header-tab-nav" aria-label="Primary sections") role="tablist"(>)',
     r'\1\2',
     html,
     count=1,
 )
-
 for tab_id in ("research", "engineer"):
-    pattern = re.compile(
-        rf'<(?:button|a)\s+([^>]*\bid="{tab_id}-tab"[^>]*)>([\s\S]*?)</(?:button|a)>'
-    )
+    pattern = re.compile(rf'<(?:button|a)\s+([^>]*\bid="{tab_id}-tab"[^>]*)>([\s\S]*?)</(?:button|a)>')
     match = pattern.search(html)
     if not match:
         raise SystemExit(f"Could not find expected {tab_id} primary navigation control")
-    attrs = match.group(1)
-    body = match.group(2)
+    attrs, body = match.group(1), match.group(2)
     for attr_pattern in (
-        r'\s+role="tab"',
-        r'\s+aria-controls="[^"]+"',
-        r'\s+aria-selected="(?:true|false)"',
-        r'\s+tabindex="-?\d+"',
-        r'\s+type="button"',
-        r'\s+href="[^"]+"',
+        r'\s+role="tab"', r'\s+aria-controls="[^"]+"', r'\s+aria-selected="(?:true|false)"',
+        r'\s+tabindex="-?\d+"', r'\s+type="button"', r'\s+href="[^"]+"',
     ):
         attrs = re.sub(attr_pattern, '', attrs)
     replacement = f'<a {attrs} href="#{tab_id}-content">{body}</a>'
@@ -337,11 +289,9 @@ for tab_id in ("research", "engineer"):
     match = pattern.search(html)
     if not match:
         raise SystemExit(f"Could not find expected {tab_id} content panel")
-    attrs = match.group(1)
-    attrs = re.sub(r'\s+role="tabpanel"', '', attrs)
+    attrs = re.sub(r'\s+role="tabpanel"', '', match.group(1))
     attrs = re.sub(r'\s+aria-labelledby="[^"]+"', '', attrs)
     html = html[:match.start()] + f'<div {attrs}>' + html[match.end():]
-
 html_path.write_text(html, encoding="utf-8")
 
 css_path = Path("style.css")
@@ -363,9 +313,6 @@ if old_css in css:
 elif new_css not in css:
     raise SystemExit("Could not find expected tab styling")
 
-# The floating table-of-contents links expose their section names on pointer
-# hover. Show the same label for keyboard focus so an icon-only control is not
-# ambiguous to sighted keyboard users.
 old_toc_tooltip = ".toc-link:hover::after { opacity: 1; visibility: visible; transform: translateY(-50%) translateX(0); }"
 new_toc_tooltip = """.toc-link:hover::after,
 .toc-link:focus-visible::after { opacity: 1; visibility: visible; transform: translateY(-50%) translateX(0); }"""
@@ -373,5 +320,25 @@ if old_toc_tooltip in css:
     css = css.replace(old_toc_tooltip, new_toc_tooltip, 1)
 elif new_toc_tooltip not in css:
     raise SystemExit("Could not find expected TOC tooltip styling")
+
+if '.app-detail-trigger {' not in css:
+    css += """
+
+.app-detail-trigger {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.app-detail-trigger:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+"""
 
 css_path.write_text(css, encoding="utf-8")


### PR DESCRIPTION
Closes #49

## What changed
- add a semantic Details / 詳細 button to each app card at runtime
- use one `openModal(card, trigger)` path for pointer-card clicks and the explicit button
- keep App Store/GitHub/Web links independent and ignore link/button clicks in the card-level handler
- return focus to the Details button when the dialog closes
- preserve Escape handling and the existing focus trap
- add restrained button/focus styling through the maintenance script so generated assets keep the behavior

## Why
The app detail dialog was pointer-only even though the dialog itself already supported keyboard focus management. Making the whole card a button would create bad nested interactive semantics because each card already contains real links. This change adds a valid keyboard entry point without changing those links or adding decorative UI.