### PR TITLE
Generate resource accessibility in the primary maintenance workflow

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -329,6 +329,7 @@ jobs:
           python scripts/maintain_filter_accessibility.py
           python scripts/maintain_storage_resilience.py
           python scripts/maintain_external_links.py
+          python scripts/maintain_resource_link_accessibility.py
           python scripts/maintain_asset_versions.py
 
       - name: Commit and Push changes

--- a/.github/workflows/resource-link-accessibility.yml
+++ b/.github/workflows/resource-link-accessibility.yml
@@ -7,43 +7,29 @@ on:
       - 'effects.js'
       - 'scripts/maintain_resource_link_accessibility.py'
       - '.github/workflows/resource-link-accessibility.yml'
-  workflow_run:
-    workflows: ['Optimize Portfolio Assets']
-    types: [completed]
+      - '.github/workflows/optimize-portfolio.yml'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: static-resource-link-accessibility
   cancel-in-progress: true
 
 jobs:
-  maintain:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.head_branch == 'main'
+  validate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout portfolio
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
 
-      - name: Generate static accessible resource names
+      - name: Validate static accessible resource names
         run: |
           python3 scripts/maintain_resource_link_accessibility.py
           cp index.html /tmp/index-after-first-run.html
           python3 scripts/maintain_resource_link_accessibility.py
           cmp /tmp/index-after-first-run.html index.html
           git diff --check
-
-      - name: Commit generated HTML
-        if: github.event_name != 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
-        with:
-          commit_message: 'Keep resource link accessibility in static HTML'
-          file_pattern: 'index.html'
-          commit_user_name: 'sakai1250'
-          commit_user_email: '92532910+sakai1250@users.noreply.github.com'
-          commit_author: 'sakai1250 <92532910+sakai1250@users.noreply.github.com>'
+          git diff --exit-code -- index.html


### PR DESCRIPTION
## Summary
- run `maintain_resource_link_accessibility.py` inside `Optimize Portfolio Assets`
- make the dedicated resource-link accessibility workflow read-only
- remove its post-optimization write path and extra maintenance commit
- fail validation when generated accessible names are stale or missing

## Why
The accessibility transform was the only generated HTML maintenance step that ran in a second write-capable workflow. That created a brief inconsistent state and an avoidable follow-up commit.

This keeps the generated state in the primary maintenance workflow while retaining a focused pull-request check with least-privilege permissions.

Closes #52