### PR TITLE
Consolidate reduced-motion maintenance

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -330,6 +330,7 @@ jobs:
           python scripts/maintain_storage_resilience.py
           python scripts/maintain_external_links.py
           python scripts/maintain_resource_link_accessibility.py
+          python scripts/maintain_reduced_motion.py
           python scripts/maintain_asset_versions.py
 
       - name: Commit and Push changes

--- a/.github/workflows/reduced-motion-maintenance.yml
+++ b/.github/workflows/reduced-motion-maintenance.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: reduced-motion-maintenance-${{ github.ref }}
@@ -26,14 +27,7 @@ jobs:
         with:
           python-version: '3.14'
 
-      - name: Keep JavaScript motion preference aligned
-        run: python scripts/maintain_reduced_motion.py
-
-      - name: Commit maintained JavaScript
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
-        with:
-          commit_message: "Respect reduced motion in stats"
-          file_pattern: "main.js"
-          commit_user_name: "sakai1250"
-          commit_user_email: "92532910+sakai1250@users.noreply.github.com"
-          commit_author: "sakai1250 <92532910+sakai1250@users.noreply.github.com>"
+      - name: Validate JavaScript motion preference
+        run: |
+          python scripts/maintain_reduced_motion.py
+          git diff --exit-code -- main.js

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ for script in \
   scripts/maintain_storage_resilience.py \
   scripts/maintain_external_links.py \
   scripts/maintain_resource_link_accessibility.py \
+  scripts/maintain_reduced_motion.py \
   scripts/maintain_asset_versions.py; do
   python3 "$script"
 done


### PR DESCRIPTION
## Summary
- run `maintain_reduced_motion.py` in the primary portfolio maintenance workflow
- make the dedicated reduced-motion workflow read-only validation instead of a second writer to `main`
- include reduced-motion maintenance in the README local-validation command

## Why
Reduced-motion behavior was maintained through a separate write-enabled workflow after the main generated-state workflow. That split could create an avoidable follow-up commit, required extra write permission, and was missing from the documented local validation path.

This keeps the visible behavior unchanged while making the generated-state path simpler and easier to reproduce locally.

Closes #55