### PR TITLE
Give app modal screenshots useful alt text

### DIFF
--- a/main.js
+++ b/main.js
@@ -254,6 +254,7 @@ function initModals() {
         if (!thumb || !cardTitle) return;
         opener = trigger;
         img.src = thumb.src;
+        img.alt = `${cardTitle.textContent.trim()} screenshot`;
         title.textContent = cardTitle.textContent;
         desc.textContent = card.querySelector('.app-desc')?.textContent || '';
         const linkSource = card.querySelector('.app-links')?.cloneNode(true);

--- a/scripts/maintain_tabs.py
+++ b/scripts/maintain_tabs.py
@@ -156,6 +156,7 @@ keyboard_modal = """function initModals() {
         if (!thumb || !cardTitle) return;
         opener = trigger;
         img.src = thumb.src;
+        img.alt = `${cardTitle.textContent.trim()} screenshot`;
         title.textContent = cardTitle.textContent;
         desc.textContent = card.querySelector('.app-desc')?.textContent || '';
         links.innerHTML = card.querySelector('.app-links')?.innerHTML || '';
@@ -235,6 +236,8 @@ elif resource_only_modal not in js:
 
 if "linkSource?.querySelector('.app-detail-trigger')?.remove();" not in js:
     raise SystemExit("App modal must exclude the Details trigger from copied resources")
+if "img.alt = `${cardTitle.textContent.trim()} screenshot`;" not in js:
+    raise SystemExit("App modal screenshot must have app-specific alternative text")
 
 accessible_toc = """function initTOC() {
     const fab = document.getElementById('toc-fab'), menu = document.getElementById('toc-menu');


### PR DESCRIPTION
## Summary
- add an app-specific `alt` value to the screenshot shown in the app detail dialog
- keep card thumbnails decorative
- make `maintain_tabs.py` generate and validate the modal screenshot alternative text

## Why
The larger screenshot in the detail dialog is meaningful content, but it currently has an empty `alt` and disappears from screen-reader output. The list thumbnail can remain decorative because the app title is adjacent.

## Validation
- only `main.js` and `scripts/maintain_tabs.py` change
- existing modal focus trap, Escape dismissal, focus return, and resource-link copying are unchanged
- maintenance now fails if the dialog image alt behavior disappears

Closes #57