### PR TITLE
Validate site integrity before Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -53,6 +53,8 @@ jobs:
               exit 1
             fi
           done
+      - name: Validate site integrity before deployment
+        run: python scripts/check_site_integrity.py
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:


### PR DESCRIPTION
Closes #67.

## What changed
- Run `scripts/check_site_integrity.py` in the Pages deployment workflow after checking deploy-critical files and before uploading the Pages artifact.
- Keep the existing behavior that deployment checks out the latest `main` branch after `Optimize Portfolio Assets` completes, regardless of that workflow's conclusion.

## Why
The deployment boundary should reject a logically invalid portfolio state even when all required files exist. This reuses the same integrity check already used locally and in CI without adding dependencies.