### PR TITLE
Share security contact validation between local checks and CI

### DIFF
--- a/.github/workflows/security-contact-check.yml
+++ b/.github/workflows/security-contact-check.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - '.well-known/security.txt'
       - 'SECURITY.md'
+      - 'scripts/check_security_contact.py'
       - '.github/workflows/security-contact-check.yml'
   pull_request:
     paths:
       - '.well-known/security.txt'
       - 'SECURITY.md'
+      - 'scripts/check_security_contact.py'
       - '.github/workflows/security-contact-check.yml'
   workflow_run:
     workflows: ['Deploy static content to Pages']
@@ -31,63 +33,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Validate security contact metadata
-        run: |
-          python - <<'PY'
-          from datetime import datetime, timezone, timedelta
-          from pathlib import Path
-          from urllib.parse import urlsplit
-
-          path = Path('.well-known/security.txt')
-          if not path.exists():
-              raise SystemExit('Missing .well-known/security.txt')
-
-          fields = {}
-          for raw_line in path.read_text(encoding='utf-8').splitlines():
-              line = raw_line.strip()
-              if not line or line.startswith('#'):
-                  continue
-              if ':' not in line:
-                  raise SystemExit(f'Invalid security.txt line: {raw_line!r}')
-              key, value = line.split(':', 1)
-              fields.setdefault(key.strip(), []).append(value.strip())
-
-          required = ['Contact', 'Canonical', 'Preferred-Languages', 'Expires']
-          missing = [key for key in required if not fields.get(key)]
-          if missing:
-              raise SystemExit(f'Missing required security.txt fields: {missing}')
-
-          canonical = fields['Canonical'][0]
-          parsed = urlsplit(canonical)
-          expected = 'https://sakai1250.github.io/.well-known/security.txt'
-          if canonical != expected or parsed.scheme != 'https':
-              raise SystemExit(f'Canonical must be {expected}')
-
-          contacts = fields['Contact']
-          if not any(value.startswith(('mailto:', 'https://')) for value in contacts):
-              raise SystemExit('Contact must include a mailto: or https:// URI')
-
-          expires_raw = fields['Expires'][0]
-          try:
-              expires = datetime.fromisoformat(expires_raw.replace('Z', '+00:00'))
-          except ValueError as exc:
-              raise SystemExit(f'Invalid Expires timestamp: {expires_raw}') from exc
-          if expires.tzinfo is None:
-              raise SystemExit('Expires must include a timezone')
-
-          now = datetime.now(timezone.utc)
-          if expires <= now:
-              raise SystemExit(f'security.txt expired at {expires.isoformat()}')
-          if expires - now < timedelta(days=30):
-              raise SystemExit(
-                  f'security.txt expires in fewer than 30 days: {expires.isoformat()}'
-              )
-
-          policy = fields.get('Policy', [])
-          if policy and not all(urlsplit(value).scheme == 'https' for value in policy):
-              raise SystemExit('Policy URLs must use HTTPS')
-
-          print(f'OK: security.txt valid through {expires.isoformat()}')
-          PY
+        run: python scripts/check_security_contact.py
       - name: Verify deployed security contact
         if: >-
           github.event_name == 'schedule' ||

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ done
 python3 scripts/check_app_repo_links.py
 python3 scripts/check_site_integrity.py
 python3 scripts/check_progressive_enhancement.py
+python3 scripts/check_security_contact.py
 git diff --exit-code -- index.html 404.html main.js effects.js style.css
 ```
 

--- a/scripts/check_security_contact.py
+++ b/scripts/check_security_contact.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+def main() -> None:
+    path = Path('.well-known/security.txt')
+    if not path.exists():
+        raise SystemExit('Missing .well-known/security.txt')
+
+    fields: dict[str, list[str]] = {}
+    for raw_line in path.read_text(encoding='utf-8').splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if ':' not in line:
+            raise SystemExit(f'Invalid security.txt line: {raw_line!r}')
+        key, value = line.split(':', 1)
+        fields.setdefault(key.strip(), []).append(value.strip())
+
+    required = ['Contact', 'Canonical', 'Preferred-Languages', 'Expires']
+    missing = [key for key in required if not fields.get(key)]
+    if missing:
+        raise SystemExit(f'Missing required security.txt fields: {missing}')
+
+    canonical = fields['Canonical'][0]
+    expected = 'https://sakai1250.github.io/.well-known/security.txt'
+    parsed = urlsplit(canonical)
+    if canonical != expected or parsed.scheme != 'https':
+        raise SystemExit(f'Canonical must be {expected}')
+
+    contacts = fields['Contact']
+    if not any(value.startswith(('mailto:', 'https://')) for value in contacts):
+        raise SystemExit('Contact must include a mailto: or https:// URI')
+
+    expires_raw = fields['Expires'][0]
+    try:
+        expires = datetime.fromisoformat(expires_raw.replace('Z', '+00:00'))
+    except ValueError as exc:
+        raise SystemExit(f'Invalid Expires timestamp: {expires_raw}') from exc
+    if expires.tzinfo is None:
+        raise SystemExit('Expires must include a timezone')
+
+    now = datetime.now(timezone.utc)
+    if expires <= now:
+        raise SystemExit(f'security.txt expired at {expires.isoformat()}')
+    if expires - now < timedelta(days=30):
+        raise SystemExit(
+            f'security.txt expires in fewer than 30 days: {expires.isoformat()}'
+        )
+
+    policy = fields.get('Policy', [])
+    if policy and not all(urlsplit(value).scheme == 'https' for value in policy):
+        raise SystemExit('Policy URLs must use HTTPS')
+
+    print(f'OK: security.txt valid through {expires.isoformat()}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- move repository-side `security.txt` validation into `scripts/check_security_contact.py`
- call the same validator from the security contact workflow
- add the validator to README local checks
- keep the deployed-file comparison in GitHub Actions because it requires network access

## Why
Local validation could previously pass while `security.txt` was expired, near expiry, malformed, or used the wrong canonical URL. This removes that local/CI mismatch without changing the public site.

Closes #71.