### PR TITLE
Share local deep-link validation between local checks and CI

### DIFF
--- a/.github/workflows/tab-maintenance-check.yml
+++ b/.github/workflows/tab-maintenance-check.yml
@@ -29,7 +29,8 @@ jobs:
             scripts/maintain_storage_resilience.py \
             scripts/maintain_external_links.py \
             scripts/maintain_asset_versions.py \
-            scripts/check_app_repo_links.py; do
+            scripts/check_app_repo_links.py \
+            scripts/check_local_deep_links.py; do
             python -m py_compile "$script"
           done
       - name: Validate maintenance state and idempotence
@@ -72,49 +73,4 @@ jobs:
       - name: Validate app repository mappings
         run: python scripts/check_app_repo_links.py
       - name: Validate local tab deep links
-        run: |
-          python - <<'PY'
-          from html.parser import HTMLParser
-          from pathlib import Path
-          from urllib.parse import urlsplit
-
-          class Parser(HTMLParser):
-              def __init__(self):
-                  super().__init__()
-                  self.ids = set()
-                  self.hrefs = []
-
-              def handle_starttag(self, tag, attrs):
-                  attrs = dict(attrs)
-                  if 'id' in attrs:
-                      self.ids.add(attrs['id'])
-                  if tag == 'a' and attrs.get('href'):
-                      self.hrefs.append(attrs['href'])
-
-          def parse(path):
-              parser = Parser()
-              parser.feed(Path(path).read_text(encoding='utf-8'))
-              return parser
-
-          index = parse('index.html')
-          problems = []
-
-          for source in ('index.html', '404.html'):
-              page = parse(source)
-              for href in page.hrefs:
-                  parsed = urlsplit(href)
-                  if parsed.scheme or parsed.netloc or not parsed.fragment:
-                      continue
-
-                  if parsed.path in ('', '/'):
-                      target_ids = page.ids if parsed.path == '' else index.ids
-                      if parsed.fragment not in target_ids:
-                          problems.append(
-                              f'{source}: local deep link {href!r} points to missing id {parsed.fragment!r}'
-                          )
-
-          if problems:
-              raise SystemExit('\n'.join(problems))
-
-          print('OK: local tab deep links resolve to existing ids')
-          PY
+        run: python scripts/check_local_deep_links.py

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ for script in \
   python3 "$script"
 done
 python3 scripts/check_app_repo_links.py
+python3 scripts/check_local_deep_links.py
 python3 scripts/check_site_integrity.py
 python3 scripts/check_progressive_enhancement.py
 python3 scripts/check_security_contact.py

--- a/scripts/check_local_deep_links.py
+++ b/scripts/check_local_deep_links.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate local fragment links in the portfolio HTML files."""
+
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+class Parser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.ids = set()
+        self.hrefs = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if "id" in attrs:
+            self.ids.add(attrs["id"])
+        if tag == "a" and attrs.get("href"):
+            self.hrefs.append(attrs["href"])
+
+
+def parse(path):
+    parser = Parser()
+    parser.feed(Path(path).read_text(encoding="utf-8"))
+    return parser
+
+
+def main():
+    index = parse("index.html")
+    problems = []
+
+    for source in ("index.html", "404.html"):
+        page = parse(source)
+        for href in page.hrefs:
+            parsed = urlsplit(href)
+            if parsed.scheme or parsed.netloc or not parsed.fragment:
+                continue
+
+            if parsed.path in ("", "/"):
+                target_ids = page.ids if parsed.path == "" else index.ids
+                if parsed.fragment not in target_ids:
+                    problems.append(
+                        f"{source}: local deep link {href!r} points to missing id {parsed.fragment!r}"
+                    )
+
+    if problems:
+        raise SystemExit("\n".join(problems))
+
+    print("OK: local tab deep links resolve to existing ids")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extract the existing local fragment-link validator into `scripts/check_local_deep_links.py`
- call the shared validator from `Interaction maintenance check`
- add the same check to the documented local validation flow

## Why
This removes the remaining workflow-only implementation for local section links. Research, Engineering, and other fragment links can now be checked before push with the exact same implementation used by CI.

## Scope
No portfolio content, styling, or navigation targets are changed. This only shares the existing validation behavior.

Closes #77