### PR TITLE
Validate llms.txt profile consistency

### DIFF
--- a/.github/workflows/structured-profile.yml
+++ b/.github/workflows/structured-profile.yml
@@ -21,3 +21,5 @@ jobs:
           python-version: '3.14'
       - name: Validate JSON-LD person metadata
         run: python scripts/check_structured_profile.py
+      - name: Validate machine-readable profile routes
+        run: python scripts/check_llms_profile.py

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ python3 scripts/check_site_integrity.py
 python3 scripts/check_progressive_enhancement.py
 python3 scripts/check_security_contact.py
 python3 scripts/check_structured_profile.py
+python3 scripts/check_llms_profile.py
 git diff --exit-code -- index.html 404.html main.js effects.js style.css sitemap.xml
 ```
 

--- a/scripts/check_llms_profile.py
+++ b/scripts/check_llms_profile.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+def require(text, needle, source):
+    if needle not in text:
+        raise SystemExit(f"{source} is missing required profile content: {needle}")
+
+
+def main():
+    llms_path = Path("llms.txt")
+    cv_path = Path("assets/cv.txt")
+
+    llms_text = llms_path.read_text(encoding="utf-8")
+    cv_text = cv_path.read_text(encoding="utf-8")
+
+    required_identity = [
+        "# Taigo Sakai",
+        "English name: Taigo Sakai",
+        "Japanese name: 坂井 泰吾",
+        "Publication name: T. Sakai",
+        "Current role: Ph.D. student and Special Assistant at Meijo University",
+    ]
+    for item in required_identity:
+        require(llms_text, item, "llms.txt")
+
+    required_routes = [
+        "https://sakai1250.github.io/assets/cv.txt",
+        "https://sakai1250.github.io/assets/cv.pdf",
+        "https://sakai1250.github.io/",
+        "https://sakai1250.github.io/#research-content",
+        "https://sakai1250.github.io/#engineer-content",
+        "https://github.com/sakai1250/sakai1250.github.io",
+    ]
+    for route in required_routes:
+        require(llms_text, route, "llms.txt")
+
+    required_profiles = [
+        "https://github.com/sakai1250",
+        "https://qiita.com/sakai1250",
+        "https://www.linkedin.com/in/sakai1250",
+        "https://scholar.google.com/citations?user=eS-5wrQAAAAJ",
+        "mailto:263441505@ccmailg.meijo-u.ac.jp",
+    ]
+    for profile in required_profiles:
+        require(llms_text, profile, "llms.txt")
+
+    shared_identity = [
+        "Taigo Sakai",
+        "Ph.D. Student",
+        "Special Assistant",
+        "Meijo University",
+        "https://sakai1250.github.io/",
+    ]
+    for item in shared_identity:
+        require(cv_text, item, "assets/cv.txt")
+
+    for profile in required_profiles[:-1]:
+        require(cv_text, profile, "assets/cv.txt")
+
+    print("OK: llms.txt and assets/cv.txt expose a consistent professional profile")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_llms_profile.py
+++ b/scripts/check_llms_profile.py
@@ -7,6 +7,11 @@ def require(text, needle, source):
         raise SystemExit(f"{source} is missing required profile content: {needle}")
 
 
+def require_casefold(text, needle, source):
+    if needle.casefold() not in text.casefold():
+        raise SystemExit(f"{source} is missing required profile content: {needle}")
+
+
 def main():
     llms_path = Path("llms.txt")
     cv_path = Path("assets/cv.txt")
@@ -50,10 +55,10 @@ def main():
         "Ph.D. Student",
         "Special Assistant",
         "Meijo University",
-        "https://sakai1250.github.io/",
     ]
     for item in shared_identity:
-        require(cv_text, item, "assets/cv.txt")
+        require_casefold(cv_text, item, "assets/cv.txt")
+    require(cv_text, "https://sakai1250.github.io/", "assets/cv.txt")
 
     for profile in required_profiles[:-1]:
         require(cv_text, profile, "assets/cv.txt")


### PR DESCRIPTION
Closes #83.

## What changed

- add `scripts/check_llms_profile.py` to validate the machine-readable identity, current role and affiliation, portfolio routes, and professional profile links
- cross-check the core identity and professional links against `assets/cv.txt`
- run the check from README local validation
- run the same check in the Structured profile GitHub Actions workflow

## Why

`llms.txt` is a public source for machine-readable visitors, but it was previously checked only for file existence. This makes the repository enforce its documented requirement that the visible profile, CV, and `llms.txt` stay aligned.

No portfolio content or visual presentation changes are included.