### PR TITLE
Validate portfolio navigation before Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -57,6 +57,10 @@ jobs:
         run: python scripts/check_site_integrity.py
       - name: Validate progressive enhancement before deployment
         run: python scripts/check_progressive_enhancement.py
+      - name: Validate local deep links before deployment
+        run: python scripts/check_local_deep_links.py
+      - name: Validate app repository links before deployment
+        run: python scripts/check_app_repo_links.py
       - name: Validate structured profile before deployment
         run: python scripts/check_structured_profile.py
       - name: Validate machine-readable profile before deployment


### PR DESCRIPTION
## Summary

- run the existing local deep-link check before uploading the Pages artifact
- run the existing app repository/product mapping check at the same point
- keep network-dependent link checks out of the deployment path

## Rationale

These checks protect useful navigation that matters directly to research visitors and recruiters, and both are deterministic and dependency-free. Reusing the existing scripts also avoids duplicating validation logic.

Closes #90.