### PR TITLE
Validate accessibility maintenance before Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -67,6 +67,14 @@ jobs:
         run: python scripts/check_llms_profile.py
       - name: Validate security contact before deployment
         run: python scripts/check_security_contact.py
+      - name: Validate accessible resource names before deployment
+        run: |
+          python scripts/maintain_resource_link_accessibility.py
+          git diff --exit-code -- index.html
+      - name: Validate reduced-motion support before deployment
+        run: |
+          python scripts/maintain_reduced_motion.py
+          git diff --exit-code -- main.js
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:


### PR DESCRIPTION
Closes #92.

## What changed

- run the existing accessible resource-name maintenance before Pages artifact upload
- fail deployment if that script would change `index.html`
- run the existing reduced-motion maintenance before Pages artifact upload
- fail deployment if that script would change `main.js`

## Why

The deploy workflow deliberately does not depend on portfolio optimization succeeding because optimization uses external resources. These two accessibility contracts are deterministic and dependency-free, so they should be enforced directly at deployment rather than relying on a separate workflow having run successfully.

No visible design or portfolio content changes are included.