### PR TITLE
Validate contact and filter interactions before Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -67,6 +67,14 @@ jobs:
         run: python scripts/check_llms_profile.py
       - name: Validate security contact before deployment
         run: python scripts/check_security_contact.py
+      - name: Validate contact form maintenance before deployment
+        run: |
+          python scripts/maintain_contact_form.py
+          git diff --exit-code -- index.html main.js
+      - name: Validate filter accessibility before deployment
+        run: |
+          python scripts/maintain_filter_accessibility.py
+          git diff --exit-code -- index.html main.js
       - name: Validate accessible resource names before deployment
         run: |
           python scripts/maintain_resource_link_accessibility.py


### PR DESCRIPTION
## Summary

- run the existing contact-form maintainer before Pages artifact upload
- run the existing research/engineering filter accessibility maintainer before Pages artifact upload
- fail deployment if either deterministic maintainer would modify `index.html` or `main.js`
- keep the deploy gate network-independent

## Why

Pages deployment is intentionally allowed to proceed when the optimizer fails on external resources. These checks ensure that the primary contact path and research-output filtering cannot bypass their local maintenance rules in that fallback path.

Closes #94.