### PR TITLE
Validate static fallback metadata before Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -83,6 +83,10 @@ jobs:
         run: |
           python scripts/maintain_reduced_motion.py
           git diff --exit-code -- main.js
+      - name: Validate static fallback metadata before deployment
+        run: |
+          python scripts/maintain_static_fallbacks.py
+          git diff --exit-code -- index.html sitemap.xml
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:


### PR DESCRIPTION
## Summary

- run the existing static fallback maintainer immediately before Pages artifact upload
- fail deployment if the maintainer would change `index.html` or `sitemap.xml`
- keep the check deterministic and network-free

## Why

The separate static-fallback synchronization workflow can race with Pages deployment. This final gate prevents stale visible counts, footer update metadata, or sitemap dates from being published before the synchronization commit lands.

## Perspectives

- **Researcher:** keeps publication, award, and app summary counts aligned with current content.
- **Recruiter:** avoids temporarily stale visible summary information and update dates.
- **Engineer:** removes reliance on cross-workflow timing by enforcing the existing maintenance contract at deployment.

Closes #96.