### PR TITLE
Validate visible profile metadata before Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -61,6 +61,10 @@ jobs:
         run: python scripts/check_local_deep_links.py
       - name: Validate app repository links before deployment
         run: python scripts/check_app_repo_links.py
+      - name: Validate visible profile metadata before deployment
+        run: |
+          python scripts/maintain_profile_metadata.py
+          git diff --exit-code -- index.html
       - name: Validate structured profile before deployment
         run: python scripts/check_structured_profile.py
       - name: Validate machine-readable profile before deployment


### PR DESCRIPTION
## Summary
Run the deterministic profile metadata maintainer immediately before the existing structured-profile deployment checks.

The deployment now fails if `scripts/maintain_profile_metadata.py` would change `index.html`, which protects the visible role text, browser/Open Graph/X titles, affiliation wording, and canonical URL from being published in a stale state.

This adds no network dependency and does not change the visible portfolio content when the repository is already consistent.

Closes #100.