### PR TITLE
Centralize deterministic maintenance validation

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -73,15 +73,7 @@ jobs:
         run: python scripts/check_security_contact.py
       - name: Validate full interaction maintenance before deployment
         run: |
-          python scripts/maintain_tabs.py
-          python scripts/maintain_contact_form.py
-          python scripts/maintain_header_controls.py
-          python scripts/maintain_filter_accessibility.py
-          python scripts/maintain_storage_resilience.py
-          python scripts/maintain_external_links.py
-          python scripts/maintain_resource_link_accessibility.py
-          python scripts/maintain_reduced_motion.py
-          python scripts/maintain_asset_versions.py
+          python scripts/run_deterministic_maintenance.py
           git diff --exit-code -- index.html 404.html main.js effects.js style.css
       - name: Validate static fallback metadata before deployment
         run: |

--- a/.github/workflows/tab-maintenance-check.yml
+++ b/.github/workflows/tab-maintenance-check.yml
@@ -21,28 +21,12 @@ jobs:
           python-version: '3.x'
       - name: Validate maintenance scripts
         run: |
-          for script in \
-            scripts/maintain_tabs.py \
-            scripts/maintain_contact_form.py \
-            scripts/maintain_header_controls.py \
-            scripts/maintain_filter_accessibility.py \
-            scripts/maintain_storage_resilience.py \
-            scripts/maintain_external_links.py \
-            scripts/maintain_asset_versions.py \
-            scripts/check_app_repo_links.py \
-            scripts/check_local_deep_links.py; do
-            python -m py_compile "$script"
-          done
+          python scripts/run_deterministic_maintenance.py --compile-only
+          python -m py_compile scripts/check_app_repo_links.py scripts/check_local_deep_links.py
       - name: Validate maintenance state and idempotence
         run: |
           run_maintenance() {
-            python scripts/maintain_tabs.py
-            python scripts/maintain_contact_form.py
-            python scripts/maintain_header_controls.py
-            python scripts/maintain_filter_accessibility.py
-            python scripts/maintain_storage_resilience.py
-            python scripts/maintain_external_links.py
-            python scripts/maintain_asset_versions.py
+            python scripts/run_deterministic_maintenance.py
           }
 
           tracked_site_files=(index.html 404.html main.js effects.js style.css)

--- a/README.md
+++ b/README.md
@@ -40,20 +40,9 @@ Before opening a pull request, install the maintenance dependency and run the sa
 ```bash
 python3 -m pip install -r requirements-maintenance.txt
 python3 -m py_compile scripts/*.py
-for script in \
-  scripts/maintain_tabs.py \
-  scripts/maintain_contact_form.py \
-  scripts/maintain_header_controls.py \
-  scripts/maintain_profile_metadata.py \
-  scripts/maintain_filter_accessibility.py \
-  scripts/maintain_storage_resilience.py \
-  scripts/maintain_external_links.py \
-  scripts/maintain_resource_link_accessibility.py \
-  scripts/maintain_reduced_motion.py \
-  scripts/maintain_asset_versions.py \
-  scripts/maintain_static_fallbacks.py; do
-  python3 "$script"
-done
+python3 scripts/run_deterministic_maintenance.py
+python3 scripts/maintain_profile_metadata.py
+python3 scripts/maintain_static_fallbacks.py
 python3 scripts/check_app_repo_links.py
 python3 scripts/check_local_deep_links.py
 python3 scripts/check_site_integrity.py

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Run the dependency-free deterministic portfolio maintenance transforms."""
+
+from __future__ import annotations
+
+import argparse
+import py_compile
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+MAINTENANCE_SCRIPTS = (
+    "scripts/maintain_tabs.py",
+    "scripts/maintain_contact_form.py",
+    "scripts/maintain_header_controls.py",
+    "scripts/maintain_filter_accessibility.py",
+    "scripts/maintain_storage_resilience.py",
+    "scripts/maintain_external_links.py",
+    "scripts/maintain_resource_link_accessibility.py",
+    "scripts/maintain_reduced_motion.py",
+    "scripts/maintain_asset_versions.py",
+)
+
+
+def compile_scripts() -> None:
+    for relative_path in MAINTENANCE_SCRIPTS:
+        py_compile.compile(str(ROOT / relative_path), doraise=True)
+
+
+def run_scripts() -> None:
+    for relative_path in MAINTENANCE_SCRIPTS:
+        subprocess.run(
+            [sys.executable, str(ROOT / relative_path)],
+            cwd=ROOT,
+            check=True,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        help="Compile the maintenance scripts without executing them.",
+    )
+    args = parser.parse_args()
+
+    if args.compile_only:
+        compile_scripts()
+    else:
+        run_scripts()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/run_deterministic_maintenance.py` as the shared deterministic maintenance runner
- use the runner in interaction CI and the Pages pre-deploy gate
- simplify README local validation to use the same runner
- include resource-link accessibility and reduced-motion maintenance in the shared interaction check instead of relying only on separate workflows

## Why
The same deterministic script list was being copied across multiple validation paths. A shared runner reduces drift and makes a future maintenance addition easier to apply consistently before review and deployment.

The network-dependent image/README optimization work remains separate; this change only centralizes deterministic local transforms.

Closes #102