### PR TITLE
Run progressive enhancement checks before merge

### DIFF
--- a/.github/workflows/progressive-enhancement.yml
+++ b/.github/workflows/progressive-enhancement.yml
@@ -9,6 +9,13 @@ on:
       - main.js
       - scripts/check_progressive_enhancement.py
       - .github/workflows/progressive-enhancement.yml
+  pull_request:
+    paths:
+      - index.html
+      - style.css
+      - main.js
+      - scripts/check_progressive_enhancement.py
+      - .github/workflows/progressive-enhancement.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- run the existing progressive-enhancement validation on pull requests
- use the same path filter already used for pushes to `main`
- keep the validation logic itself unchanged

## Why

The check protects the portfolio from hiding primary content behind JavaScript and from adding render-blocking external stylesheets. Running it only after merge means review can succeed before that regression is reported.

This moves the failure point into the pull request, where the change can be fixed before it reaches `main`.

No visible portfolio content or styling changes.

Closes #108