### PR TITLE
Validate year filter coverage against dated entries

### DIFF
--- a/.github/workflows/tab-maintenance-check.yml
+++ b/.github/workflows/tab-maintenance-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Validate maintenance scripts
         run: |
           python scripts/run_deterministic_maintenance.py --compile-only
-          python -m py_compile scripts/check_app_repo_links.py scripts/check_local_deep_links.py scripts/sync_readme_assets.py
+          python -m py_compile scripts/check_app_repo_links.py scripts/check_local_deep_links.py scripts/check_year_filter_coverage.py scripts/sync_readme_assets.py
       - name: Validate maintenance state and idempotence
         run: |
           run_maintenance() {
@@ -58,3 +58,5 @@ jobs:
         run: python scripts/check_app_repo_links.py
       - name: Validate local tab deep links
         run: python scripts/check_local_deep_links.py
+      - name: Validate year filter coverage
+        run: python scripts/check_year_filter_coverage.py

--- a/scripts/check_year_filter_coverage.py
+++ b/scripts/check_year_filter_coverage.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Keep visible year-filter choices aligned with dated research/profile entries."""
+
+from pathlib import Path
+import re
+
+
+html = Path("index.html").read_text(encoding="utf-8")
+
+research_start = html.find('<div id="research-content"')
+engineer_start = html.find('<div id="engineer-content"')
+if research_start == -1 or engineer_start == -1 or engineer_start <= research_start:
+    raise SystemExit("Could not isolate Research content")
+
+research_html = html[research_start:engineer_start]
+content_years = set(
+    re.findall(r'<li\b[^>]*\bdata-year="(\d{4})"', research_html)
+)
+filter_years = set(
+    re.findall(r'<button\b[^>]*\bdata-year="(\d{4})"', html[:research_start])
+)
+
+if not content_years:
+    raise SystemExit("Research content has no dated entries")
+if not filter_years:
+    raise SystemExit("Year filter has no numeric choices")
+
+missing = sorted(content_years - filter_years, reverse=True)
+stale = sorted(filter_years - content_years, reverse=True)
+problems = []
+if missing:
+    problems.append(f"year filter is missing content years: {', '.join(missing)}")
+if stale:
+    problems.append(f"year filter contains years with no dated content: {', '.join(stale)}")
+if problems:
+    raise SystemExit("\n".join(problems))
+
+print(
+    "OK: year filter covers all dated Research entries: "
+    + ", ".join(sorted(content_years, reverse=True))
+)


### PR DESCRIPTION
## Summary
- add a read-only check that compares visible year-filter choices with dated entries in `#research-content`
- fail when a content year has no filter choice or a filter year has no dated content
- run the check in the existing Interaction maintenance workflow

This prevents dated publications, awards, education, internships, and related entries from becoming unreachable through the visible year navigation after future updates.

Closes #114.