### PR TITLE
Validate accessible names for interactive controls

### DIFF
--- a/.github/workflows/site-integrity.yml
+++ b/.github/workflows/site-integrity.yml
@@ -25,3 +25,5 @@ jobs:
           node --check effects.js
       - name: Check links, accessibility basics, generated data, CV text, and indexing files
         run: python scripts/check_site_integrity.py
+      - name: Check interactive control names
+        run: python scripts/check_control_accessible_names.py

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ python3 scripts/maintain_static_fallbacks.py
 python3 scripts/check_app_repo_links.py
 python3 scripts/check_local_deep_links.py
 python3 scripts/check_site_integrity.py
+python3 scripts/check_control_accessible_names.py
 python3 scripts/check_progressive_enhancement.py
 python3 scripts/check_security_contact.py
 python3 scripts/check_structured_profile.py

--- a/scripts/check_control_accessible_names.py
+++ b/scripts/check_control_accessible_names.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+class ControlNameParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.current_button = None
+        self.unnamed_buttons = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != 'button':
+            return
+        attrs = dict(attrs)
+        self.current_button = {
+            'id': attrs.get('id', ''),
+            'aria_label': attrs.get('aria-label', '').strip(),
+            'aria_labelledby': attrs.get('aria-labelledby', '').strip(),
+            'text': [],
+        }
+
+    def handle_data(self, data):
+        if self.current_button is not None:
+            self.current_button['text'].append(data)
+
+    def handle_endtag(self, tag):
+        if tag != 'button' or self.current_button is None:
+            return
+        control = self.current_button
+        visible_text = ''.join(control['text']).strip()
+        if not (visible_text or control['aria_label'] or control['aria_labelledby']):
+            identifier = f"#{control['id']}" if control['id'] else '<button>'
+            self.unnamed_buttons.append(identifier)
+        self.current_button = None
+
+
+problems = []
+for html_path in (Path('index.html'), Path('404.html')):
+    parser = ControlNameParser()
+    parser.feed(html_path.read_text(encoding='utf-8'))
+    if parser.unnamed_buttons:
+        problems.append(
+            f"{html_path}: buttons missing an accessible name {parser.unnamed_buttons}"
+        )
+
+if problems:
+    raise SystemExit('\n'.join(problems))
+
+print('OK: interactive buttons expose visible text or an ARIA accessible name')


### PR DESCRIPTION
## Summary
- add a dependency-free HTML check for unnamed `<button>` controls
- run it in the existing Site integrity workflow
- document the same validation in the local pre-PR checklist

## Why
A button can remain visually correct while losing its accessible name after a markup refactor. Existing checks validate ARIA references and form labels but do not catch this case.

This protects research filters and primary recruiter-facing controls such as language/theme actions without changing the site's appearance.

Closes #116