### PR TITLE
Validate accessible names for links

### DIFF
--- a/scripts/check_control_accessible_names.py
+++ b/scripts/check_control_accessible_names.py
@@ -6,45 +6,54 @@ from pathlib import Path
 class ControlNameParser(HTMLParser):
     def __init__(self):
         super().__init__()
-        self.current_button = None
-        self.unnamed_buttons = []
+        self.current_control = None
+        self.unnamed_controls = []
 
     def handle_starttag(self, tag, attrs):
-        if tag != 'button':
-            return
         attrs = dict(attrs)
-        self.current_button = {
+        is_control = tag == 'button' or (tag == 'a' and attrs.get('href'))
+        if not is_control:
+            return
+        self.current_control = {
+            'tag': tag,
             'id': attrs.get('id', ''),
+            'href': attrs.get('href', ''),
             'aria_label': attrs.get('aria-label', '').strip(),
             'aria_labelledby': attrs.get('aria-labelledby', '').strip(),
             'text': [],
         }
 
     def handle_data(self, data):
-        if self.current_button is not None:
-            self.current_button['text'].append(data)
+        if self.current_control is not None:
+            self.current_control['text'].append(data)
 
     def handle_endtag(self, tag):
-        if tag != 'button' or self.current_button is None:
+        if self.current_control is None or tag != self.current_control['tag']:
             return
-        control = self.current_button
+        control = self.current_control
         visible_text = ''.join(control['text']).strip()
         if not (visible_text or control['aria_label'] or control['aria_labelledby']):
-            identifier = f"#{control['id']}" if control['id'] else '<button>'
-            self.unnamed_buttons.append(identifier)
-        self.current_button = None
+            if control['id']:
+                identifier = f"#{control['id']}"
+            elif control['tag'] == 'a':
+                identifier = f"<a href={control['href']!r}>"
+            else:
+                identifier = '<button>'
+            self.unnamed_controls.append(identifier)
+        self.current_control = None
 
 
 problems = []
 for html_path in (Path('index.html'), Path('404.html')):
     parser = ControlNameParser()
     parser.feed(html_path.read_text(encoding='utf-8'))
-    if parser.unnamed_buttons:
+    if parser.unnamed_controls:
         problems.append(
-            f"{html_path}: buttons missing an accessible name {parser.unnamed_buttons}"
+            f"{html_path}: interactive controls missing an accessible name "
+            f"{parser.unnamed_controls}"
         )
 
 if problems:
     raise SystemExit('\n'.join(problems))
 
-print('OK: interactive buttons expose visible text or an ARIA accessible name')
+print('OK: links and buttons expose visible text or an ARIA accessible name')

--- a/scripts/check_control_accessible_names.py
+++ b/scripts/check_control_accessible_names.py
@@ -11,6 +11,12 @@ class ControlNameParser(HTMLParser):
 
     def handle_starttag(self, tag, attrs):
         attrs = dict(attrs)
+        if self.current_control is not None and tag == 'img':
+            alt = attrs.get('alt', '').strip()
+            if alt:
+                self.current_control['text'].append(alt)
+            return
+
         is_control = tag == 'button' or (tag == 'a' and attrs.get('href'))
         if not is_control:
             return
@@ -31,8 +37,8 @@ class ControlNameParser(HTMLParser):
         if self.current_control is None or tag != self.current_control['tag']:
             return
         control = self.current_control
-        visible_text = ''.join(control['text']).strip()
-        if not (visible_text or control['aria_label'] or control['aria_labelledby']):
+        accessible_text = ''.join(control['text']).strip()
+        if not (accessible_text or control['aria_label'] or control['aria_labelledby']):
             if control['id']:
                 identifier = f"#{control['id']}"
             elif control['tag'] == 'a':
@@ -56,4 +62,4 @@ for html_path in (Path('index.html'), Path('404.html')):
 if problems:
     raise SystemExit('\n'.join(problems))
 
-print('OK: links and buttons expose visible text or an ARIA accessible name')
+print('OK: links and buttons expose text, image alt text, or an ARIA accessible name')


### PR DESCRIPTION
Closes #118.

## What changed

- Extend `scripts/check_control_accessible_names.py` from buttons to both buttons and `<a href>` links.
- Accept visible text, informative image `alt` text, `aria-label`, or `aria-labelledby` as accessible-name sources.
- Report unnamed links with their `href` so CI failures are actionable.
- Reuse the existing Site integrity workflow; no new workflow or dependency is added.

## Validation note

The first CI run correctly exposed a limitation in the new checker: three image-only organization links were reported as unnamed even though their `<img alt>` values provide accessible names. The checker now accounts for image alt text instead of forcing unnecessary HTML changes.

## Why

The site already protects buttons from becoming unnamed, but recruiter-facing CV/contact/GitHub links and researcher-facing publication/resource links could still regress to unnamed controls without CI noticing.

## Scope

One validation script only. No HTML, CSS, JavaScript, visual, or portfolio-content changes.