### PR TITLE
Remove conflicting legacy form-label validation

### DIFF
--- a/scripts/check_site_integrity.py
+++ b/scripts/check_site_integrity.py
@@ -21,8 +21,6 @@ class Parser(HTMLParser):
         self.refs = []
         self.aria_id_refs = []
         self.img_without_alt = []
-        self.form_control_ids = []
-        self.label_fors = []
         self.html_lang = None
         self.has_main = False
 
@@ -43,13 +41,6 @@ class Parser(HTMLParser):
             self.has_main = True
         elif tag == 'img' and 'alt' not in attrs:
             self.img_without_alt.append(attrs.get('src', '<inline image>'))
-        elif tag in ('input', 'textarea', 'select'):
-            control_id = attrs.get('id')
-            control_type = attrs.get('type', '').lower()
-            if control_id and control_type != 'hidden':
-                self.form_control_ids.append(control_id)
-        elif tag == 'label' and attrs.get('for'):
-            self.label_fors.append(attrs['for'])
 
 
 for html_path in html_files:
@@ -70,10 +61,6 @@ for html_path in html_files:
         problems.append(f'{html_path}: missing <main> landmark')
     if parser.img_without_alt:
         problems.append(f'{html_path}: images missing alt attributes {parser.img_without_alt}')
-
-    unlabeled = sorted(set(parser.form_control_ids) - set(parser.label_fors))
-    if unlabeled:
-        problems.append(f'{html_path}: form controls missing matching <label for> {unlabeled}')
 
     ids = set(parser.ids)
     for attr, ref in parser.aria_id_refs:

--- a/scripts/maintain_resource_link_accessibility.py
+++ b/scripts/maintain_resource_link_accessibility.py
@@ -68,13 +68,13 @@ def update_publication_links(text: str) -> tuple[str, int]:
 
 def update_award_links(text: str) -> tuple[str, int]:
     item_pattern = re.compile(r'<li\b[^>]*data-year="[^"]+"[^>]*>[\s\S]*?</li>')
-    anchor_pattern = re.compile(r'<a\b[^>]*>\[Link\]</a>')
+    anchor_pattern = re.compile(r'<a\b[^>]*>\[(?:Link|Details)\]</a>')
     updated_count = 0
 
     def update_item(match: re.Match[str]) -> str:
         nonlocal updated_count
         item = match.group(0)
-        if "[Link]" not in item:
+        if "[Link]" not in item and "[Details]" not in item:
             return item
 
         english_match = re.search(r'<span lang="en">([\s\S]*?)</span>', item)
@@ -89,7 +89,8 @@ def update_award_links(text: str) -> tuple[str, int]:
             anchor = anchor_match.group(0)
             updated_count += 1
             anchor = set_aria_label(anchor, f"Award details: {award}")
-            return anchor.replace(">[Link]</a>", ">[Details]</a>", 1)
+            anchor = anchor.replace(">[Link]</a>", ">[Details]</a>", 1)
+            return anchor
 
         return anchor_pattern.sub(update_anchor, item)
 


### PR DESCRIPTION
Closes #124 and #126.

## What changed
- Removed the older `<label for>`-only form-control validation from `check_site_integrity.py`.
- Kept `check_form_control_names.py` as the single authoritative accessible-name check for form controls.
- Made award-link accessibility maintenance recognize both `[Link]` and the already-normalized `[Details]` state so repeated maintenance runs stay idempotent.

## Why
The dedicated form-control check correctly accepts explicit or implicit labels, `aria-label`, valid `aria-labelledby`, and native names for button-like inputs. The older site-integrity rule could reject valid accessible markup and made CI behavior inconsistent.

The award-link transform also failed after its own first successful run because it only searched for the pre-transform `[Link]` label. That broke the repository's deterministic maintenance check.

## Scope
No portfolio content, styling, or runtime behavior changes. These are CI and maintenance reliability fixes.