### PR TITLE
Keep external app title links non-destructive

### DIFF
--- a/scripts/maintain_external_links.py
+++ b/scripts/maintain_external_links.py
@@ -9,6 +9,11 @@ GENERIC_LINK_RE = re.compile(
     r'(?P<label>\[Link\])(?P<close></a>)',
     re.IGNORECASE,
 )
+APP_TITLE_ANCHOR_RE = re.compile(
+    r'<a\b(?=[^>]*\bclass=(?P<cq>["\'])[^"\']*\bapp-title\b[^"\']*(?P=cq))'
+    r'(?=[^>]*\bhref=(?P<hq>["\'])(?P<href>https?://.*?)(?P=hq))[^>]*>',
+    re.IGNORECASE,
+)
 
 PAPER_HOSTS = (
     'arxiv.org/',
@@ -37,6 +42,13 @@ def secure_anchor(tag: str) -> str:
     return tag[:-1] + ' rel="noopener noreferrer">'
 
 
+def keep_external_app_title_non_destructive(match: re.Match[str]) -> str:
+    tag = match.group(0)
+    if re.search(r'\btarget=(["\'])_blank\1', tag, re.IGNORECASE):
+        return secure_anchor(tag)
+    return secure_anchor(tag[:-1] + ' target="_blank">')
+
+
 def clarify_resource_label(match: re.Match[str]) -> str:
     href = match.group('href').lower()
     if any(host in href for host in PAPER_HOSTS):
@@ -63,6 +75,7 @@ for path in TARGET_FILES:
         continue
     text = path.read_text(encoding='utf-8')
     updated = remove_stale_profile_links(text)
+    updated = APP_TITLE_ANCHOR_RE.sub(keep_external_app_title_non_destructive, updated)
     updated = ANCHOR_RE.sub(lambda match: secure_anchor(match.group(0)), updated)
     updated = GENERIC_LINK_RE.sub(clarify_resource_label, updated)
     path.write_text(updated, encoding='utf-8')


### PR DESCRIPTION
Closes #127

## What changed
- Extend existing external-link maintenance to cover external `.app-title` links.
- Keep those links on `target="_blank"`.
- Reuse the existing `rel="noopener noreferrer"` hardening.
- Keep the transformation idempotent when a link is already correct.

## Why
Visitors often open an app repository to inspect implementation details. Replacing the portfolio tab makes comparison across projects harder and is inconsistent with the primary GitHub navigation.

## Scope
No styling, internal navigation, card/modal behavior, or link destinations are changed.