### PR TITLE
Validate security on new-tab links

### DIFF
--- a/.github/workflows/site-integrity.yml
+++ b/.github/workflows/site-integrity.yml
@@ -29,3 +29,5 @@ jobs:
         run: python scripts/check_control_accessible_names.py
       - name: Check form control names
         run: python scripts/check_form_control_names.py
+      - name: Check new-tab link security
+        run: python scripts/check_new_tab_link_security.py

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ python3 scripts/check_local_deep_links.py
 python3 scripts/check_site_integrity.py
 python3 scripts/check_control_accessible_names.py
 python3 scripts/check_form_control_names.py
+python3 scripts/check_new_tab_link_security.py
 python3 scripts/check_progressive_enhancement.py
 python3 scripts/check_security_contact.py
 python3 scripts/check_structured_profile.py

--- a/scripts/check_new_tab_link_security.py
+++ b/scripts/check_new_tab_link_security.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+HTML_FILES = [Path('index.html'), Path('404.html')]
+problems = []
+checked_links = 0
+
+
+class LinkParser(HTMLParser):
+    def __init__(self, path: Path):
+        super().__init__()
+        self.path = path
+
+    def handle_starttag(self, tag, attrs):
+        global checked_links
+        if tag != 'a':
+            return
+
+        attrs = dict(attrs)
+        if attrs.get('target', '').lower() != '_blank':
+            return
+
+        checked_links += 1
+        rel_tokens = {token.lower() for token in attrs.get('rel', '').split()}
+        if 'noopener' not in rel_tokens:
+            href = attrs.get('href', '<missing href>')
+            problems.append(
+                f'{self.path}: target="_blank" link is missing rel="noopener": {href}'
+            )
+
+
+for html_path in HTML_FILES:
+    if not html_path.exists():
+        problems.append(f'missing HTML file {html_path}')
+        continue
+
+    parser = LinkParser(html_path)
+    parser.feed(html_path.read_text(encoding='utf-8'))
+
+if problems:
+    raise SystemExit('\n'.join(problems))
+
+print(f'OK: {checked_links} new-tab links include rel="noopener"')


### PR DESCRIPTION
Closes #129.

## What changed
- add a dependency-free HTML check for links that use `target="_blank"`
- require those links to include `rel="noopener"`
- run the check in Site integrity CI
- document the same command in the local validation steps

## Why
Several maintenance helpers already add `noopener noreferrer`, but the repository did not enforce the rule globally. This makes future external-link edits fail fast if opener protection is accidentally removed.

No visible content, styling, or navigation behavior is changed.