### PR TITLE
Gate Pages deployment on integrity checks

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -55,10 +55,18 @@ jobs:
           done
       - name: Validate site integrity before deployment
         run: python scripts/check_site_integrity.py
+      - name: Validate interactive accessible names before deployment
+        run: python scripts/check_control_accessible_names.py
+      - name: Validate form control names before deployment
+        run: python scripts/check_form_control_names.py
+      - name: Validate new-tab link security before deployment
+        run: python scripts/check_new_tab_link_security.py
       - name: Validate progressive enhancement before deployment
         run: python scripts/check_progressive_enhancement.py
       - name: Validate local deep links before deployment
         run: python scripts/check_local_deep_links.py
+      - name: Validate year filter coverage before deployment
+        run: python scripts/check_year_filter_coverage.py
       - name: Validate app repository links before deployment
         run: python scripts/check_app_repo_links.py
       - name: Validate visible profile metadata before deployment


### PR DESCRIPTION
## Summary
Add the existing fast, deterministic integrity checks to the GitHub Pages deployment gate so a failing direct push cannot be published just because the review CI runs independently.

## Changes
- validate interactive control/link accessible names before deployment
- validate form-control accessible names before deployment
- validate `target="_blank"` link security before deployment
- validate research year-filter coverage before deployment

These checks already exist in repository CI; this PR only makes deployment enforce them too. No network-dependent validation is added to the deploy path.

Closes #131.