### PR TITLE
Move app repository alignment into deterministic maintenance

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -54,43 +54,6 @@ jobs:
               raise SystemExit('Thumbnail cleanup still depends on current-run download success')
           PY
 
-      - name: Keep app repository links aligned
-        run: |
-          python <<'PY'
-          import re
-          from pathlib import Path
-
-          path = Path('index.html')
-          text = path.read_text(encoding='utf-8')
-
-          def align_app_repo(title, expected_repo):
-              global text
-              marker = f'>{title}</a>'
-              start = text.find(marker)
-              if start == -1:
-                  raise SystemExit(f'Could not find app title: {title}')
-
-              next_card = text.find('<div class="app-card"', start + len(marker))
-              end = next_card if next_card != -1 else len(text)
-              block = text[start:end]
-              pattern = re.compile(
-                  r'href="https://github\.com/sakai1250/(?:PresentMemo|otsuri_docter)"(?P<attrs>[^>]*)>GitHub</a>'
-              )
-              def replacement(match):
-                  return (
-                      f'href="https://github.com/sakai1250/{expected_repo}"'
-                      f'{match.group("attrs")}>GitHub</a>'
-                  )
-              updated, count = pattern.subn(replacement, block, count=1)
-              if count != 1:
-                  raise SystemExit(f'Expected one GitHub link in app card: {title}')
-              text = text[:start] + updated + text[end:]
-
-          align_app_repo('おつりDoctor (iOS)', 'otsuri_docter')
-          align_app_repo('MAIORAL (iOS)', 'PresentMemo')
-          path.write_text(text, encoding='utf-8')
-          PY
-
       - name: Keep profile metadata aligned
         run: python scripts/maintain_profile_metadata.py
 

--- a/scripts/maintain_app_repo_links.py
+++ b/scripts/maintain_app_repo_links.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Keep app cards linked to their intended GitHub repositories."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+INDEX = Path("index.html")
+EXPECTED_REPOS = {
+    "おつりDoctor (iOS)": "otsuri_docter",
+    "MAIORAL (iOS)": "PresentMemo",
+}
+APP_CARD_MARKER = '<div class="app-card"'
+REPO_LINK = re.compile(
+    r'href="https://github\.com/sakai1250/(?:PresentMemo|otsuri_docter)"(?P<attrs>[^>]*)>\s*GitHub\s*</a>'
+)
+
+
+def align_app_repo(text: str, title: str, expected_repo: str) -> str:
+    title_marker = f">{title}</a>"
+    title_pos = text.find(title_marker)
+    if title_pos == -1:
+        raise SystemExit(f"Could not find app title: {title}")
+
+    start = text.rfind(APP_CARD_MARKER, 0, title_pos)
+    if start == -1:
+        raise SystemExit(f"Could not find app card for: {title}")
+
+    next_card = text.find(APP_CARD_MARKER, title_pos + len(title_marker))
+    end = next_card if next_card != -1 else len(text)
+    block = text[start:end]
+
+    def replacement(match: re.Match[str]) -> str:
+        return (
+            f'href="https://github.com/sakai1250/{expected_repo}"'
+            f'{match.group("attrs")}>GitHub</a>'
+        )
+
+    updated, count = REPO_LINK.subn(replacement, block, count=1)
+    if count != 1:
+        raise SystemExit(f"Expected one GitHub link in app card: {title}")
+
+    return text[:start] + updated + text[end:]
+
+
+def main() -> None:
+    text = INDEX.read_text(encoding="utf-8")
+    for title, expected_repo in EXPECTED_REPOS.items():
+        text = align_app_repo(text, title, expected_repo)
+    INDEX.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -20,6 +20,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_external_links.py",
     "scripts/maintain_resource_link_accessibility.py",
     "scripts/maintain_reduced_motion.py",
+    "scripts/maintain_app_repo_links.py",
     "scripts/maintain_asset_versions.py",
 )
 


### PR DESCRIPTION
## Summary
- move the おつりDoctor / MAIORAL repository correction out of inline workflow Python
- add a dedicated dependency-free maintenance script
- run that script through the same deterministic maintenance entrypoint used by local validation and CI
- keep the existing independent `check_app_repo_links.py` validation unchanged

## Why
This removes a one-off maintenance path from the GitHub Actions YAML. The same transform can now be compiled and exercised locally, by CI maintenance checks, and by the optimization workflow.

## Scope
No visual change and no intended link-destination change.

Closes #133