### PR TITLE
Keep deep links reachable across tabs

### DIFF
--- a/scripts/maintain_tab_deep_links.py
+++ b/scripts/maintain_tab_deep_links.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+js_path = Path("main.js")
+js = js_path.read_text(encoding="utf-8")
+
+old = """    const tabFromHash = () => {
+        const match = window.location.hash.match(/^#([a-z0-9-]+)-content$/i);
+        return match && validTabs.has(match[1]) ? match[1] : null;
+    };
+"""
+
+new = """    const tabFromHash = () => {
+        const match = window.location.hash.match(/^#([a-z0-9-]+)-content$/i);
+        if (match && validTabs.has(match[1])) return match[1];
+
+        const rawHash = window.location.hash.slice(1);
+        if (!rawHash) return null;
+
+        let targetId;
+        try { targetId = decodeURIComponent(rawHash); } catch { targetId = rawHash; }
+        const target = document.getElementById(targetId);
+        const content = target?.closest('.tab-content');
+        if (!content?.id.endsWith('-content')) return null;
+
+        const id = content.id.replace(/-content$/, '');
+        return validTabs.has(id) ? id : null;
+    };
+"""
+
+if new not in js:
+    if old not in js:
+        raise SystemExit("Could not find expected tab hash resolver")
+    js = js.replace(old, new, 1)
+
+for marker in (
+    "const target = document.getElementById(targetId);",
+    "const content = target?.closest('.tab-content');",
+    "return validTabs.has(id) ? id : null;",
+):
+    if marker not in js:
+        raise SystemExit(f"Missing deep-link tab marker: {marker}")
+
+js_path.write_text(js, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -13,6 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 MAINTENANCE_SCRIPTS = (
     "scripts/maintain_tabs.py",
+    "scripts/maintain_tab_deep_links.py",
     "scripts/maintain_contact_form.py",
     "scripts/maintain_header_controls.py",
     "scripts/maintain_filter_accessibility.py",


### PR DESCRIPTION
## Summary
- resolve any existing fragment target to the `.tab-content` that contains it
- preserve the existing `#research-content` / `#engineer-content` handling
- register the transform in deterministic maintenance so generated `main.js` keeps the behavior

## Why
The header Contact link points to `#contact`, but Contact is inside the Engineering panel. Once JavaScript hides the inactive panel, `#contact` can point at hidden content unless the tab resolver activates the containing panel first.

This keeps direct links useful for recruiters and makes semantic section links safer to share without changing the visual presentation.

Closes #143