### PR TITLE
Scroll semantic deep links after revealing tabs

### DIFF
--- a/scripts/maintain_tab_deep_links.py
+++ b/scripts/maintain_tab_deep_links.py
@@ -10,7 +10,7 @@ old = """    const tabFromHash = () => {
     };
 """
 
-new = """    const tabFromHash = () => {
+resolved = """    const tabFromHash = () => {
         const match = window.location.hash.match(/^#([a-z0-9-]+)-content$/i);
         if (match && validTabs.has(match[1])) return match[1];
 
@@ -28,15 +28,65 @@ new = """    const tabFromHash = () => {
     };
 """
 
-if new not in js:
-    if old not in js:
+scrolled = resolved + """    const scrollHashTarget = () => {
+        const rawHash = window.location.hash.slice(1);
+        if (!rawHash) return;
+
+        let targetId;
+        try { targetId = decodeURIComponent(rawHash); } catch { targetId = rawHash; }
+        const target = document.getElementById(targetId);
+        if (!target || target.classList.contains('tab-content')) return;
+
+        window.requestAnimationFrame(() => {
+            window.scrollTo({
+                top: target.getBoundingClientRect().top + window.scrollY - getStickyOffset(),
+                behavior: 'auto'
+            });
+        });
+    };
+"""
+
+if scrolled not in js:
+    if resolved in js:
+        js = js.replace(resolved, scrolled, 1)
+    elif old in js:
+        js = js.replace(old, scrolled, 1)
+    else:
         raise SystemExit("Could not find expected tab hash resolver")
-    js = js.replace(old, new, 1)
+
+old_navigation = """    const initialTab = tabFromHash() || Array.from(tabItems).find(i => i.classList.contains('active'))?.getAttribute('data-tab');
+    if (initialTab) switchTab(initialTab);
+    window.addEventListener('hashchange', () => {
+        const tab = tabFromHash();
+        if (tab) switchTab(tab);
+    });
+"""
+
+new_navigation = """    const initialTab = tabFromHash() || Array.from(tabItems).find(i => i.classList.contains('active'))?.getAttribute('data-tab');
+    if (initialTab) {
+        switchTab(initialTab);
+        scrollHashTarget();
+    }
+    window.addEventListener('hashchange', () => {
+        const tab = tabFromHash();
+        if (!tab) return;
+        switchTab(tab);
+        scrollHashTarget();
+    });
+"""
+
+if new_navigation not in js:
+    if old_navigation not in js:
+        raise SystemExit("Could not find expected deep-link navigation handling")
+    js = js.replace(old_navigation, new_navigation, 1)
 
 for marker in (
     "const target = document.getElementById(targetId);",
     "const content = target?.closest('.tab-content');",
     "return validTabs.has(id) ? id : null;",
+    "const scrollHashTarget = () => {",
+    "target.getBoundingClientRect().top + window.scrollY - getStickyOffset()",
+    "scrollHashTarget();",
 ):
     if marker not in js:
         raise SystemExit(f"Missing deep-link tab marker: {marker}")


### PR DESCRIPTION
## Summary
- reveal the portfolio tab that contains a semantic fragment target;
- after the target becomes visible, scroll it into view using the existing sticky-header offset;
- apply the same handling on initial page load and later `hashchange` navigation;
- keep primary `#research-content` / `#engineer-content` tab links unchanged.

## Why
The existing deep-link resolver can reveal `#contact` inside Engineering, but native fragment scrolling may happen while that tab is still hidden. This leaves the correct URL and tab visible without moving the viewport to the requested section.

## Maintenance
The behavior remains in `scripts/maintain_tab_deep_links.py`, so deterministic maintenance owns the generated `main.js` change.

Closes #145.