### PR TITLE
Keep section deep links stable across reordering

### DIFF
--- a/scripts/maintain_stable_section_ids.py
+++ b/scripts/maintain_stable_section_ids.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+path = Path("main.js")
+js = path.read_text(encoding="utf-8")
+
+position_based = """function getSectionId(content, section, index) {
+    const currentId = section?.id || '';
+    const generatedId = /^(?:(?:research|engineer|portfolio)-)?section-\\d+$/;
+    if (currentId && !generatedId.test(currentId)) return currentId;
+
+    const prefix = content?.id?.replace(/-content$/, '') || 'portfolio';
+    return `${prefix}-section-${index}`;
+}
+"""
+
+semantic = """function getSectionId(content, section, index) {
+    const currentId = section?.id || '';
+    const generatedId = /^(?:(?:research|engineer|portfolio)-)?section-\\d+$/;
+    if (currentId && !generatedId.test(currentId)) return currentId;
+
+    const prefix = content?.id?.replace(/-content$/, '') || 'portfolio';
+    const englishTitle = section?.querySelector('.section-title [lang=\"en\"]')?.textContent.trim() || '';
+    const slug = englishTitle
+        .toLowerCase()
+        .replace(/&/g, ' and ')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    return slug ? `${prefix}-${slug}` : `${prefix}-section-${index}`;
+}
+"""
+
+if position_based in js:
+    js = js.replace(position_based, semantic, 1)
+elif semantic not in js:
+    raise SystemExit("Could not find expected section ID generation")
+
+required_markers = (
+    "const englishTitle = section?.querySelector('.section-title [lang=\"en\"]')?.textContent.trim() || '';",
+    "return slug ? `${prefix}-${slug}` : `${prefix}-section-${index}`;",
+)
+for marker in required_markers:
+    if marker not in js:
+        raise SystemExit(f"Missing stable section ID marker: {marker}")
+
+path.write_text(js, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -13,6 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 MAINTENANCE_SCRIPTS = (
     "scripts/maintain_tabs.py",
+    "scripts/maintain_stable_section_ids.py",
     "scripts/maintain_tab_deep_links.py",
     "scripts/maintain_contact_form.py",
     "scripts/maintain_header_controls.py",


### PR DESCRIPTION
## Summary
- generate semantic section IDs from each section's English heading instead of its position
- preserve explicit semantic IDs such as `contact`
- keep a position-based fallback only when no usable English heading exists
- run the transform through deterministic maintenance

## Why
Position-based anchors can silently point to a different section after a section is inserted or reordered. Stable semantic anchors make research, project, and recruiter-facing deep links safer to share and bookmark.

Closes #147