### PR TITLE
Guard generated section IDs against collisions

### DIFF
--- a/scripts/check_local_deep_links.py
+++ b/scripts/check_local_deep_links.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Validate local fragment links and unique ids in portfolio HTML files."""
+"""Validate local fragment links and unique static/runtime section ids."""
 
-from collections import Counter
+from collections import Counter, defaultdict
 from html.parser import HTMLParser
 from pathlib import Path
+import re
 from urllib.parse import urlsplit
+
+
+GENERATED_SECTION_ID = re.compile(r"^(?:(?:research|engineer|portfolio)-)?section-\d+$")
 
 
 class Parser(HTMLParser):
@@ -12,13 +16,65 @@ class Parser(HTMLParser):
         super().__init__()
         self.ids = []
         self.hrefs = []
+        self.sections = []
+        self._current_tab = None
+        self._current_section = None
+        self._in_section_title = False
+        self._capture_english_title = False
+        self._div_states = []
+        self._span_states = []
 
     def handle_starttag(self, tag, attrs):
         attrs = dict(attrs)
+        classes = set(attrs.get("class", "").split())
+
         if "id" in attrs:
             self.ids.append(attrs["id"])
         if tag == "a" and attrs.get("href"):
             self.hrefs.append(attrs["href"])
+
+        if tag == "div":
+            self._div_states.append(
+                (self._current_tab, self._current_section, self._in_section_title)
+            )
+
+            element_id = attrs.get("id", "")
+            if "tab-content" in classes and element_id.endswith("-content"):
+                self._current_tab = element_id.removesuffix("-content")
+
+            if "section-card" in classes and self._current_tab:
+                self._current_section = {
+                    "tab": self._current_tab,
+                    "explicit_id": attrs.get("id", ""),
+                    "english_title_parts": [],
+                }
+                self.sections.append(self._current_section)
+
+            if "section-title" in classes and self._current_section is not None:
+                self._in_section_title = True
+
+        elif tag == "span":
+            self._span_states.append(self._capture_english_title)
+            if (
+                self._current_section is not None
+                and self._in_section_title
+                and attrs.get("lang") == "en"
+            ):
+                self._capture_english_title = True
+
+    def handle_data(self, data):
+        if self._capture_english_title and self._current_section is not None:
+            self._current_section["english_title_parts"].append(data)
+
+    def handle_endtag(self, tag):
+        if tag == "span" and self._span_states:
+            self._capture_english_title = self._span_states.pop()
+        elif tag == "div" and self._div_states:
+            (
+                self._current_tab,
+                self._current_section,
+                self._in_section_title,
+            ) = self._div_states.pop()
 
 
 def parse(path):
@@ -27,9 +83,43 @@ def parse(path):
     return parser
 
 
+def slugify_section_title(title):
+    return re.sub(r"^-+|-+$", "", re.sub(r"[^a-z0-9]+", "-", title.lower().replace("&", " and ")))
+
+
+def generated_section_ids(page):
+    indexes = defaultdict(int)
+    generated = []
+
+    for section in page.sections:
+        tab = section["tab"] or "portfolio"
+        index = indexes[tab]
+        indexes[tab] += 1
+
+        current_id = section["explicit_id"]
+        if current_id and not GENERATED_SECTION_ID.fullmatch(current_id):
+            section_id = current_id
+        else:
+            english_title = "".join(section["english_title_parts"]).strip()
+            slug = slugify_section_title(english_title)
+            section_id = f"{tab}-{slug}" if slug else f"{tab}-section-{index}"
+
+        generated.append((section_id, section))
+
+    return generated
+
+
 def main():
     index = parse("index.html")
     problems = []
+
+    runtime_sections = generated_section_ids(index)
+    runtime_counts = Counter(section_id for section_id, _ in runtime_sections)
+    for section_id, count in sorted(runtime_counts.items()):
+        if count > 1:
+            problems.append(
+                f"index.html: runtime section id {section_id!r} would be generated {count} times"
+            )
 
     for source in ("index.html", "404.html"):
         page = parse(source)
@@ -56,7 +146,7 @@ def main():
     if problems:
         raise SystemExit("\n".join(problems))
 
-    print("OK: local deep links resolve and HTML ids are unique")
+    print("OK: local deep links resolve and static/runtime section ids are unique")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #149

Validate runtime section IDs derived from English headings so duplicate generated deep-link targets fail CI. This is validation-only and does not change visible portfolio content.