### PR TITLE
Keep badge heading hierarchy semantic

### DIFF
--- a/scripts/maintain_heading_hierarchy.py
+++ b/scripts/maintain_heading_hierarchy.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Keep badge subsection headings semantically ordered without changing their appearance."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX_PATH = ROOT / "index.html"
+STYLE_PATH = ROOT / "style.css"
+
+BADGE_IDS = ("badges-languages", "badges-frameworks", "badges-orgs")
+
+
+def update_badge_heading(html: str, badge_id: str) -> tuple[str, bool]:
+    pattern = re.compile(
+        rf'(<div\s+class="badge-row"\s+id="{re.escape(badge_id)}"[^>]*>\s*)'
+        r'<h[34]>(.*?)</h[34]>',
+        re.DOTALL,
+    )
+    match = pattern.search(html)
+    if not match:
+        raise SystemExit(f"Could not find badge heading for #{badge_id}")
+
+    replacement = f"{match.group(1)}<h3>{match.group(2)}</h3>"
+    updated = html[: match.start()] + replacement + html[match.end() :]
+    return updated, updated != html
+
+
+def main() -> None:
+    html = INDEX_PATH.read_text(encoding="utf-8")
+    changed = False
+
+    for badge_id in BADGE_IDS:
+        html, did_change = update_badge_heading(html, badge_id)
+        changed = changed or did_change
+
+    style = STYLE_PATH.read_text(encoding="utf-8")
+    if ".badge-row h4 {" in style:
+        style = style.replace(".badge-row h4 {", ".badge-row h3 {", 1)
+        changed = True
+    elif ".badge-row h3 {" not in style:
+        raise SystemExit("Could not find badge heading style selector")
+
+    if changed:
+        INDEX_PATH.write_text(html, encoding="utf-8")
+        STYLE_PATH.write_text(style, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -18,6 +18,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_contact_form.py",
     "scripts/maintain_header_controls.py",
     "scripts/maintain_filter_accessibility.py",
+    "scripts/maintain_heading_hierarchy.py",
     "scripts/maintain_storage_resilience.py",
     "scripts/maintain_external_links.py",
     "scripts/maintain_resource_link_accessibility.py",


### PR DESCRIPTION
Closes #151

## What changed
- Add deterministic maintenance that keeps the three Tech Stack & Organizations subsection labels at `h3` beneath the section `h2`.
- Update the matching CSS selector from `.badge-row h4` to `.badge-row h3` so the visual appearance stays unchanged.
- Run the new transform as part of the existing deterministic maintenance sequence.

## Why
The current `h2` → `h4` jump makes heading navigation less predictable for screen-reader users. The change fixes document structure without adding visual decoration or changing content.

## Scope
Only the three badge-row subsection headings and their existing style selector are affected.