### PR TITLE
Keep SCAT grant status consistent across languages

### DIFF
--- a/scripts/maintain_scat_grant_status.py
+++ b/scripts/maintain_scat_grant_status.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Keep the SCAT Research Grant status consistent across Japanese and English."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / "index.html"
+
+text = INDEX.read_text(encoding="utf-8")
+
+stale = "SCAT Research Grant, Encouragement Prize (Declined due to duplicate funding)"
+current = "SCAT Research Grant, Encouragement Prize (Declined)"
+
+if stale in text:
+    text = text.replace(stale, current)
+
+if "SCAT研究助成 研究奨励金 採択(辞退)" not in text:
+    raise SystemExit("Expected Japanese SCAT grant status was not found")
+if current not in text:
+    raise SystemExit("Expected English SCAT grant status was not found")
+if stale in text:
+    raise SystemExit("Stale SCAT grant decline reason remains")
+
+INDEX.write_text(text, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -19,6 +19,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_header_controls.py",
     "scripts/maintain_filter_accessibility.py",
     "scripts/maintain_heading_hierarchy.py",
+    "scripts/maintain_scat_grant_status.py",
     "scripts/maintain_storage_resilience.py",
     "scripts/maintain_external_links.py",
     "scripts/maintain_resource_link_accessibility.py",


### PR DESCRIPTION
## Summary
- align the English SCAT grant status with the simplified Japanese wording
- add deterministic maintenance so the stale decline reason is not reintroduced

## Why
The Japanese portfolio now says `採択(辞退)`, while English still exposes `Declined due to duplicate funding`. The same achievement should not reveal different detail depending on the selected language.

Closes #153