### PR TITLE
Serialize generated portfolio maintenance

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -64,7 +64,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "chore: update portfolio assets and optimized images"
-          file_pattern: "assets/* index.html 404.html main.js style.css"
+          file_pattern: "assets/* index.html 404.html main.js style.css sitemap.xml"
           commit_user_name: "sakai1250"
           commit_user_email: "92532910+sakai1250@users.noreply.github.com"
           commit_author: "sakai1250 <92532910+sakai1250@users.noreply.github.com>"

--- a/.github/workflows/static-fallbacks.yml
+++ b/.github/workflows/static-fallbacks.yml
@@ -1,16 +1,6 @@
 name: Keep static fallbacks aligned
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'index.html'
-      - 'main.js'
-      - 'style.css'
-      - 'effects.js'
-      - 'sitemap.xml'
-      - 'scripts/maintain_static_fallbacks.py'
-      - '.github/workflows/static-fallbacks.yml'
   pull_request:
     paths:
       - 'index.html'
@@ -19,7 +9,9 @@ on:
       - 'effects.js'
       - 'sitemap.xml'
       - 'scripts/maintain_static_fallbacks.py'
+      - 'scripts/run_deterministic_maintenance.py'
       - '.github/workflows/static-fallbacks.yml'
+      - '.github/workflows/optimize-portfolio.yml'
   workflow_dispatch:
 
 permissions:
@@ -31,7 +23,6 @@ concurrency:
 
 jobs:
   validate:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -45,33 +36,6 @@ jobs:
         run: |
           python3 scripts/maintain_static_fallbacks.py
           if ! git diff --exit-code -- index.html sitemap.xml; then
-            echo 'Static fallback metadata is stale. Run scripts/maintain_static_fallbacks.py and commit the result.'
+            echo 'Static fallback metadata is stale. Run scripts/run_deterministic_maintenance.py and commit the result.'
             exit 1
           fi
-
-  sync:
-    if: github.event_name != 'pull_request'
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-
-      - name: Sync visible fallback metadata
-        run: python3 scripts/maintain_static_fallbacks.py
-
-      - name: Commit synchronized fallbacks
-        run: |
-          git config user.name 'sakai1250'
-          git config user.email '92532910+sakai1250@users.noreply.github.com'
-          git add index.html sitemap.xml
-          if git diff --cached --quiet; then
-            echo 'Portfolio fallbacks already aligned.'
-            exit 0
-          fi
-          git commit -m 'Keep visible portfolio fallbacks current'
-          git push

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -26,6 +26,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_reduced_motion.py",
     "scripts/maintain_app_repo_links.py",
     "scripts/maintain_asset_versions.py",
+    "scripts/maintain_static_fallbacks.py",
 )
 
 


### PR DESCRIPTION
Closes #157.

The previous `main` push exposed a race between two workflows that both write generated files back to the branch. `Keep static fallbacks aligned` pushed first, then `Optimize Portfolio Assets` failed with a non-fast-forward push while trying to update the asset cache key. The custom Pages deploy consequently rejected `main` because `effects.js` and its `index.html` cache key no longer matched.

This change makes `Optimize Portfolio Assets` the single writer for deterministic generated portfolio files:
- include `maintain_static_fallbacks.py` in the deterministic maintenance runner;
- include `sitemap.xml` in the generated-file commit scope;
- make the dedicated static-fallback workflow validation-only for pull requests and manual checks.

This keeps the existing fallback validation while removing the competing push to `main`.