### PR TITLE
Keep SCAT grant status aligned across portfolio sources

### DIFF
--- a/assets/cv.txt
+++ b/assets/cv.txt
@@ -84,7 +84,7 @@ AWARDS & GRANTS
 - The Telecommunications Advancement Foundation Overseas Travel Expense Support - 2026
 - Research Grant for Graduate Students (B) - 2026
 - IEICE Tokai Branch Student Research Encouragement Award - 2026
-- SCAT Research Grant, Encouragement Prize, declined due to duplicate funding - 2026
+- SCAT Research Grant, Encouragement Prize (Declined) - 2026
 - Rinnai Scholarship Foundation Scholarship Student - 2026
 - DIA2026 Encouragement Award - 3/96 presentations - 2026
 - Meijo University President's Award - 2025

--- a/scripts/maintain_scat_grant_status.py
+++ b/scripts/maintain_scat_grant_status.py
@@ -1,24 +1,35 @@
 #!/usr/bin/env python3
-"""Keep the SCAT Research Grant status consistent across Japanese and English."""
+"""Keep the SCAT Research Grant status consistent across portfolio sources."""
 
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 INDEX = ROOT / "index.html"
+CV_TEXT = ROOT / "assets" / "cv.txt"
 
-text = INDEX.read_text(encoding="utf-8")
+index_text = INDEX.read_text(encoding="utf-8")
+cv_text = CV_TEXT.read_text(encoding="utf-8")
 
-stale = "SCAT Research Grant, Encouragement Prize (Declined due to duplicate funding)"
-current = "SCAT Research Grant, Encouragement Prize (Declined)"
+stale_index = "SCAT Research Grant, Encouragement Prize (Declined due to duplicate funding)"
+current_index = "SCAT Research Grant, Encouragement Prize (Declined)"
+stale_cv = "SCAT Research Grant, Encouragement Prize, declined due to duplicate funding - 2026"
+current_cv = "SCAT Research Grant, Encouragement Prize (Declined) - 2026"
 
-if stale in text:
-    text = text.replace(stale, current)
+if stale_index in index_text:
+    index_text = index_text.replace(stale_index, current_index)
+if stale_cv in cv_text:
+    cv_text = cv_text.replace(stale_cv, current_cv)
 
-if "SCAT研究助成 研究奨励金 採択(辞退)" not in text:
+if "SCAT研究助成 研究奨励金 採択(辞退)" not in index_text:
     raise SystemExit("Expected Japanese SCAT grant status was not found")
-if current not in text:
+if current_index not in index_text:
     raise SystemExit("Expected English SCAT grant status was not found")
-if stale in text:
-    raise SystemExit("Stale SCAT grant decline reason remains")
+if stale_index in index_text:
+    raise SystemExit("Stale SCAT grant decline reason remains in index.html")
+if current_cv not in cv_text:
+    raise SystemExit("Expected SCAT grant status was not found in assets/cv.txt")
+if stale_cv in cv_text:
+    raise SystemExit("Stale SCAT grant decline reason remains in assets/cv.txt")
 
-INDEX.write_text(text, encoding="utf-8")
+INDEX.write_text(index_text, encoding="utf-8")
+CV_TEXT.write_text(cv_text, encoding="utf-8")


### PR DESCRIPTION
Closes #159.

## What changed
- Align `assets/cv.txt` with the visible portfolio wording: `SCAT Research Grant, Encouragement Prize (Declined)`.
- Extend `maintain_scat_grant_status.py` so it checks and repairs both `index.html` and `assets/cv.txt`.
- Fail maintenance if the stale `declined due to duplicate funding` wording remains in either source.

## Why
The same award should not expose different wording to human visitors and machine-readable consumers such as recruiters, search tools, or LLMs.

## Scope
No layout, styling, navigation, publication, or award-status changes beyond wording consistency.