### PR TITLE
Make theme toggle action explicit to screen readers

### DIFF
--- a/scripts/maintain_theme_toggle_accessibility.py
+++ b/scripts/maintain_theme_toggle_accessibility.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Keep the theme toggle's accessible action aligned with the current theme."""
+
+from pathlib import Path
+
+
+path = Path("main.js")
+text = path.read_text(encoding="utf-8")
+
+legacy = "        if (btn) btn.setAttribute('aria-pressed', String(t === 'dark'));"
+current = """        if (btn) {
+            btn.removeAttribute('aria-pressed');
+            btn.setAttribute(
+                'aria-label',
+                t === 'dark'
+                    ? 'Switch to light theme / ライトテーマに切り替え'
+                    : 'Switch to dark theme / ダークテーマに切り替え'
+            );
+        }"""
+
+if legacy in text:
+    text = text.replace(legacy, current, 1)
+elif current not in text:
+    raise SystemExit("Could not find expected theme toggle state handling")
+
+if "if (btn) btn.setAttribute('aria-pressed'" in text:
+    raise SystemExit("Theme toggle still exposes ambiguous aria-pressed state")
+
+for expected in (
+    "Switch to light theme / ライトテーマに切り替え",
+    "Switch to dark theme / ダークテーマに切り替え",
+):
+    if expected not in text:
+        raise SystemExit(f"Missing theme toggle accessible action: {expected}")
+
+path.write_text(text, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -17,6 +17,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_tab_deep_links.py",
     "scripts/maintain_contact_form.py",
     "scripts/maintain_header_controls.py",
+    "scripts/maintain_theme_toggle_accessibility.py",
     "scripts/maintain_filter_accessibility.py",
     "scripts/maintain_heading_hierarchy.py",
     "scripts/maintain_scat_grant_status.py",


### PR DESCRIPTION
## Summary
- add deterministic maintenance for the theme toggle's accessible action
- register the new maintenance step with the existing interaction maintenance runner
- replace the ambiguous pressed state with an explicit next-action label when maintenance runs

## Why
The visual icon changes between moon and sun, but the accessible name stays generic. Screen-reader users should hear whether the button will switch to light or dark mode.

## Scope
Accessibility and maintenance only. No visual changes.

Closes #163