### PR TITLE
Make language toggle action explicit to screen readers

### DIFF
--- a/scripts/maintain_language_toggle_accessibility.py
+++ b/scripts/maintain_language_toggle_accessibility.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Keep the language toggle's accessible action aligned with the current language."""
+
+from pathlib import Path
+
+
+index_path = Path("index.html")
+index_text = index_path.read_text(encoding="utf-8")
+
+legacy_buttons = (
+    '<button class="header-btn" id="lang-toggle" type="button">',
+    '<button class="header-btn" id="lang-toggle" type="button" aria-label="Switch language / 言語切り替え">',
+)
+current_button = (
+    '<button class="header-btn" id="lang-toggle" type="button" '
+    'aria-label="Switch to English / 英語に切り替え">'
+)
+
+for legacy in legacy_buttons:
+    if legacy in index_text:
+        index_text = index_text.replace(legacy, current_button, 1)
+        break
+else:
+    if current_button not in index_text:
+        raise SystemExit("Could not find expected language toggle button")
+
+if index_text.count(current_button) != 1:
+    raise SystemExit("Language toggle must have exactly one initial accessible action")
+
+index_path.write_text(index_text, encoding="utf-8")
+
+main_path = Path("main.js")
+main_text = main_path.read_text(encoding="utf-8")
+
+legacy_anchor = """        safeStorageSet('lang', l);
+        const s = document.getElementById('search');"""
+current_block = """        safeStorageSet('lang', l);
+
+        if (btn) {
+            btn.setAttribute(
+                'aria-label',
+                l === 'ja'
+                    ? 'Switch to English / 英語に切り替え'
+                    : 'Switch to Japanese / 日本語に切り替え'
+            );
+        }
+        const s = document.getElementById('search');"""
+
+if current_block not in main_text:
+    if legacy_anchor not in main_text:
+        raise SystemExit("Could not find language toggle state handling")
+    main_text = main_text.replace(legacy_anchor, current_block, 1)
+
+if main_text.count(current_block) != 1:
+    raise SystemExit("Language toggle must have exactly one accessible action block")
+
+for expected in (
+    "Switch to English / 英語に切り替え",
+    "Switch to Japanese / 日本語に切り替え",
+):
+    if expected not in main_text:
+        raise SystemExit(f"Missing language toggle accessible action: {expected}")
+
+main_path.write_text(main_text, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -22,6 +22,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_scat_grant_status.py",
     "scripts/maintain_storage_resilience.py",
     "scripts/maintain_theme_toggle_accessibility.py",
+    "scripts/maintain_language_toggle_accessibility.py",
     "scripts/maintain_external_links.py",
     "scripts/maintain_resource_link_accessibility.py",
     "scripts/maintain_reduced_motion.py",


### PR DESCRIPTION
Closes #165

## What changed
- Add deterministic maintenance for the language toggle's accessible name.
- Keep the default static label aligned with the default Japanese document language.
- Update the accessible name after every language switch so the control announces the language it will activate next.
- Register the transform in the deterministic maintenance runner.

## Expected behavior
- Japanese active: `Switch to English / 英語に切り替え`
- English active: `Switch to Japanese / 日本語に切り替え`

No visual styling or navigation structure changes.