### PR TITLE
Follow the system theme until the user chooses one

### DIFF
--- a/scripts/maintain_theme_preference_persistence.py
+++ b/scripts/maintain_theme_preference_persistence.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Persist a site theme only after an explicit user choice."""
+
+from pathlib import Path
+import re
+
+
+path = Path("main.js")
+text = path.read_text(encoding="utf-8")
+
+legacy_signature = "    const set = (t, animate) => {"
+current_signature = "    const set = (t, animate, persist = false) => {"
+if legacy_signature in text:
+    text = text.replace(legacy_signature, current_signature, 1)
+elif current_signature not in text:
+    raise SystemExit("Could not find theme setter signature")
+
+legacy_storage = "        safeStorageSet('theme', t);"
+current_storage = "        if (persist) safeStorageSet('theme', t);"
+if legacy_storage in text:
+    text = text.replace(legacy_storage, current_storage, 1)
+elif current_storage not in text:
+    raise SystemExit("Could not find theme storage update")
+
+legacy_click = "    if (btn) btn.addEventListener('click', () => set(document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark', true));"
+current_click = "    if (btn) btn.addEventListener('click', () => set(document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark', true, true));"
+if legacy_click in text:
+    text = text.replace(legacy_click, current_click, 1)
+elif current_click not in text:
+    raise SystemExit("Could not find explicit theme choice handler")
+
+initial_set = "    set(safeStorageGet('theme') || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'), false);"
+if initial_set not in text:
+    raise SystemExit("Theme initialization must keep using the saved value or current system preference")
+
+if re.search(r"^\s*safeStorageSet\('theme', t\);\s*$", text, re.MULTILINE):
+    raise SystemExit("Theme initialization still persists the resolved system preference unconditionally")
+if text.count(current_storage) != 1 or text.count(current_click) != 1:
+    raise SystemExit("Theme preference persistence must have exactly one explicit write path")
+
+path.write_text(text, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -21,6 +21,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_heading_hierarchy.py",
     "scripts/maintain_scat_grant_status.py",
     "scripts/maintain_storage_resilience.py",
+    "scripts/maintain_theme_preference_persistence.py",
     "scripts/maintain_theme_toggle_accessibility.py",
     "scripts/maintain_language_toggle_accessibility.py",
     "scripts/maintain_external_links.py",


### PR DESCRIPTION
## Summary
- keep the current OS `prefers-color-scheme` as a fallback rather than turning it into a saved site preference on first load
- persist `theme` only when the user explicitly activates the theme toggle
- add deterministic maintenance coverage so generated `main.js` keeps that behavior

## Why
The current initialization calls the same setter used by the theme button, and that setter always writes to `localStorage`. A visitor who never chooses a portfolio theme therefore gets their first observed OS theme frozen into site storage. Subsequent OS theme changes no longer affect the portfolio after refresh.

This change keeps explicit user choices persistent while allowing users with no site-specific choice to continue following their current OS preference.

Closes #167