### PR TITLE
Restore deterministic maintenance after language toggle update

### DIFF
--- a/scripts/maintain_header_controls.py
+++ b/scripts/maintain_header_controls.py
@@ -106,9 +106,13 @@ language_button_accessible = (
     '<button class="header-btn" id="lang-toggle" type="button" '
     'aria-label="Switch language / 言語切り替え">'
 )
+language_button_action = (
+    '<button class="header-btn" id="lang-toggle" type="button" '
+    'aria-label="Switch to English / 英語に切り替え">'
+)
 if language_button in text:
     text = text.replace(language_button, language_button_accessible, 1)
-elif language_button_accessible not in text:
+elif language_button_accessible not in text and language_button_action not in text:
     raise SystemExit('Could not find language toggle button')
 
 theme_button = (


### PR DESCRIPTION
Closes #169.

The action-specific language toggle label introduced for accessibility is already valid, but `maintain_header_controls.py` only recognized the older generic label. That made the deterministic maintenance chain non-idempotent and caused both the optimization and interaction-maintenance workflows to fail on `main`.

This change keeps migration support for the unlabeled and generic-label states while treating `Switch to English / 英語に切り替え` as an already-correct state. No visible portfolio content or styling changes are introduced.

Expected result: the maintenance chain can proceed past header controls again, allowing later transforms such as theme preference persistence to run and be committed normally.