### PR TITLE
Make deterministic maintenance idempotent across runners

### DIFF
--- a/scripts/maintain_static_fallbacks.py
+++ b/scripts/maintain_static_fallbacks.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Keep visible portfolio fallback counts and sitemap update dates aligned."""
 
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 import html
 import re
 import subprocess
@@ -12,6 +14,7 @@ INDEX_PATH = Path("index.html")
 SITEMAP_PATH = Path("sitemap.xml")
 TRACKED_PAGE_FILES = ("index.html", "main.js", "style.css", "effects.js")
 HOME_URL = "https://sakai1250.github.io/"
+SITE_TIMEZONE = ZoneInfo("Asia/Tokyo")
 STATIC_SITEMAP_FILES = {
     "https://sakai1250.github.io/assets/cv.pdf": "assets/cv.pdf",
     "https://sakai1250.github.io/assets/cv.txt": "assets/cv.txt",
@@ -24,22 +27,25 @@ def git_update_date(*tracked_files: str) -> str:
     dates = []
     for tracked_file in tracked_files:
         result = subprocess.run(
-            ["git", "log", "-1", "--format=%cs", "--", tracked_file],
+            ["git", "log", "-1", "--format=%cI", "--", tracked_file],
             check=True,
             capture_output=True,
             text=True,
         )
         value = result.stdout.strip()
         if value:
-            dates.append(value)
+            try:
+                timestamp = datetime.fromisoformat(value)
+            except ValueError as exc:
+                raise SystemExit(f"Unexpected source update timestamp: {value}") from exc
+            if timestamp.tzinfo is None:
+                raise SystemExit(f"Source update timestamp has no timezone: {value}")
+            dates.append(timestamp.astimezone(SITE_TIMEZONE).date())
 
     if not dates:
         raise SystemExit(f"Could not resolve an update date for {tracked_files}")
 
-    latest = max(dates)
-    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", latest):
-        raise SystemExit(f"Unexpected source update date: {latest}")
-    return latest
+    return max(dates).isoformat()
 
 
 def update_sitemap(lastmods: dict[str, str]) -> None:

--- a/scripts/maintain_theme_toggle_accessibility.py
+++ b/scripts/maintain_theme_toggle_accessibility.py
@@ -20,9 +20,14 @@ current = """        if (btn) {
 
 # Storage-resilience maintenance historically restored the old pressed-state
 # line. Replace it when needed, but never duplicate an already-correct action
-# block. Collapse any duplicate action blocks left by an interrupted migration.
+# block. If the current block is already present, remove the entire legacy line
+# including its leading newline so repeated maintenance does not accumulate
+# blank lines.
 if legacy in text:
-    text = text.replace(legacy, "" if current in text else current, 1)
+    if current in text:
+        text = text.replace("\n" + legacy, "", 1)
+    else:
+        text = text.replace(legacy, current, 1)
 elif current not in text:
     raise SystemExit("Could not find expected theme toggle state handling")
 


### PR DESCRIPTION
Closes #171.

Two deterministic maintenance paths still changed files on every verification pass after the generated commit:

- Theme accessibility cleanup removed a legacy `aria-pressed` line but left its newline behind, so each pass added another blank line.
- Footer and sitemap dates used Git's short calendar date from the commit's recorded timezone. Generated commits created by different runners could therefore map the same update instant to different calendar dates.

This PR removes the whole legacy theme-state line when the current action-specific accessible label is already present, and derives update dates from strict commit timestamps normalized to `Asia/Tokyo`, which matches the portfolio's primary site context.

No visible decoration or content is added. The goal is that running the deterministic maintenance repeatedly, including in the deploy runner, leaves a clean working tree.