### PR TITLE
Keep header maintenance compatible with theme action labels

### DIFF
--- a/scripts/maintain_header_controls.py
+++ b/scripts/maintain_header_controls.py
@@ -123,9 +123,13 @@ theme_button_accessible = (
     '<button class="header-btn" id="theme-toggle" type="button" '
     'aria-label="Switch theme / テーマ切り替え">'
 )
+theme_button_action = (
+    '<button class="header-btn" id="theme-toggle" type="button" '
+    'aria-label="Switch to light theme / ライトテーマに切り替え">'
+)
 if theme_button in text:
     text = text.replace(theme_button, theme_button_accessible, 1)
-elif theme_button_accessible not in text:
+elif theme_button_accessible not in text and theme_button_action not in text:
     raise SystemExit('Could not find theme toggle button')
 
 # The theme control already has an accessible name. Its moon/sun glyph is only


### PR DESCRIPTION
Closes #174.

## What changed
- accept the maintained `Switch to light theme / ライトテーマに切り替え` label as a valid theme-toggle state in `maintain_header_controls.py`
- keep `maintain_theme_toggle_accessibility.py` responsible for the explicit action wording

## Why
The current generated `index.html` is correct, but `maintain_header_controls.py` rejects that state and blocks `Deploy static content to Pages` during the deterministic maintenance validation.

## Verification
The change is intentionally limited to the compatibility check. The PR checks should confirm deterministic maintenance no longer stops at `Could not find theme toggle button` and produces no site-content diff.