### PR TITLE
Align initial language toggle action with resolved language

### DIFF
--- a/scripts/maintain_language_toggle_accessibility.py
+++ b/scripts/maintain_language_toggle_accessibility.py
@@ -36,6 +36,17 @@ language_bootstrap = """  <!-- Language Initialization: Resolve Saved or Browser
       const language = savedLanguage || (browserLanguage.startsWith('en') ? 'en' : 'ja');
       document.documentElement.setAttribute('data-lang', language);
       document.documentElement.lang = language;
+      window.addEventListener('DOMContentLoaded', () => {
+        const languageButton = document.getElementById('lang-toggle');
+        if (languageButton) {
+          languageButton.setAttribute(
+            'aria-label',
+            language === 'ja'
+              ? 'Switch to English / 英語に切り替え'
+              : 'Switch to Japanese / 日本語に切り替え'
+          );
+        }
+      });
     })();
   </script>
 """
@@ -125,6 +136,9 @@ for expected in (
     "document.documentElement.setAttribute('data-lang', language);",
     "document.documentElement.lang = language;",
     "browserLanguage.startsWith('en') ? 'en' : 'ja'",
+    "const languageButton = document.getElementById('lang-toggle');",
+    "language === 'ja'",
+    "Switch to Japanese / 日本語に切り替え",
 ):
     if expected not in index_text:
         raise SystemExit(f"Missing initial language bootstrap behavior: {expected}")


### PR DESCRIPTION
Closes #182.

## What changed
- Extend the deterministic language bootstrap so the language toggle accessible name matches the already-resolved initial language when the DOM becomes available.
- Keep the existing runtime language handler responsible for subsequent user-triggered toggles.
- Add maintenance assertions so the bootstrap keeps both target-language actions and remains reproducible.

## Why
A browser-resolved English page could briefly expose a control labelled `Switch to English`, which contradicts the current state. This keeps the initial document language and the control's announced next action consistent without changing the visual presentation.