### PR TITLE
Keep section navigation URLs shareable

### DIFF
--- a/main.js
+++ b/main.js
@@ -470,6 +470,7 @@ function updateTOC() {
         a.href = `#${s.id}`;
         a.addEventListener('click', (e) => {
             e.preventDefault();
+            history.replaceState(null, '', `#${s.id}`);
             const h = document.querySelector('.header-bar').offsetHeight;
             window.scrollTo({ top: s.getBoundingClientRect().top + window.scrollY - h - 20, behavior: 'smooth' });
             document.getElementById('toc-menu').classList.remove('show');
@@ -500,6 +501,7 @@ function getStickyOffset() {
 
 function scrollToSection(section) {
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    history.replaceState(null, '', `#${section.id}`);
     window.scrollTo({
         top: section.getBoundingClientRect().top + window.scrollY - getStickyOffset(),
         behavior: reduceMotion ? 'auto' : 'smooth'


### PR DESCRIPTION
## Summary
- Update the URL fragment when using the floating table of contents.
- Update the URL fragment when using sticky section tabs.
- Use `history.replaceState` so section navigation stays copyable without adding a browser-history entry for every click.

## Why
Researchers, recruiters, and engineers can already open direct section links, but after navigating inside the site the address bar did not reflect the section they reached. This makes copying the current research or engineering section unnecessarily awkward.

## Scope
No visual changes. Existing scroll behavior, top-level tab deep links, and reload handling remain unchanged.

Closes #184