### PR TITLE
Share the current portfolio section

### DIFF
--- a/scripts/maintain_contextual_share_link.py
+++ b/scripts/maintain_contextual_share_link.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+js_path = Path("main.js")
+js = js_path.read_text(encoding="utf-8")
+
+init_anchor = "    safeInit(initReadingProgress, 'ReadingProgress');\n"
+init_line = "    safeInit(initContextualShareLink, 'ContextualShareLink');\n"
+if init_line not in js:
+    if init_anchor not in js:
+        raise SystemExit("Could not find expected initialization anchor")
+    js = js.replace(init_anchor, init_anchor + init_line, 1)
+
+share_function = r'''
+function initContextualShareLink() {
+    const link = document.getElementById('share-btn');
+    if (!link) return;
+
+    const sync = () => {
+        const pageUrl = `${window.location.origin}${window.location.pathname}${window.location.search}${window.location.hash}`;
+        const params = new URLSearchParams({
+            text: "Check out Taigo Sakai's Portfolio!",
+            url: pageUrl,
+            via: 'ikaitaig'
+        });
+        link.href = `https://twitter.com/intent/tweet?${params.toString()}`;
+    };
+
+    link.addEventListener('focus', sync);
+    link.addEventListener('pointerdown', sync);
+    link.addEventListener('click', sync);
+    window.addEventListener('hashchange', sync);
+    sync();
+}
+'''
+
+if "function initContextualShareLink() {" not in js:
+    marker = "\n// === Core Functions ===\n"
+    if marker not in js:
+        raise SystemExit("Could not find core function marker")
+    js = js.replace(marker, marker + share_function + "\n", 1)
+
+for marker in (
+    "safeInit(initContextualShareLink, 'ContextualShareLink');",
+    "const pageUrl = `${window.location.origin}${window.location.pathname}${window.location.search}${window.location.hash}`;",
+    "new URLSearchParams({",
+    "link.addEventListener('click', sync);",
+    "window.addEventListener('hashchange', sync);",
+):
+    if marker not in js:
+        raise SystemExit(f"Missing contextual share marker: {marker}")
+
+js_path.write_text(js, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -27,6 +27,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_external_links.py",
     "scripts/maintain_resource_link_accessibility.py",
     "scripts/maintain_reduced_motion.py",
+    "scripts/maintain_contextual_share_link.py",
     "scripts/maintain_app_repo_links.py",
     "scripts/maintain_asset_versions.py",
     "scripts/maintain_static_fallbacks.py",


### PR DESCRIPTION
## Summary
- add deterministic maintenance for the footer share action
- build the X share URL from the current portfolio URL, including the active section hash
- keep the existing static homepage share link as the no-JavaScript fallback

## Why
Section navigation already creates stable shareable URLs, but the built-in Share on X action still discarded that context by always sharing the homepage. This keeps the share behavior consistent for research and engineering deep links.

Closes #192