### PR TITLE
Keep TOC targets clear of sticky navigation

### DIFF
--- a/scripts/maintain_reduced_motion.py
+++ b/scripts/maintain_reduced_motion.py
@@ -77,9 +77,17 @@ reduced_motion_toc_scroll = """            const h = document.querySelector('.he
                 behavior: reduceMotion ? 'auto' : 'smooth'
             });"""
 
+sticky_aware_toc_scroll = """            const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            window.scrollTo({
+                top: s.getBoundingClientRect().top + window.scrollY - getStickyOffset(),
+                behavior: reduceMotion ? 'auto' : 'smooth'
+            });"""
+
 if legacy_toc_scroll in text:
-    text = text.replace(legacy_toc_scroll, reduced_motion_toc_scroll, 1)
-elif reduced_motion_toc_scroll not in text:
+    text = text.replace(legacy_toc_scroll, sticky_aware_toc_scroll, 1)
+elif reduced_motion_toc_scroll in text:
+    text = text.replace(reduced_motion_toc_scroll, sticky_aware_toc_scroll, 1)
+elif sticky_aware_toc_scroll not in text:
     raise SystemExit('Could not find the expected table-of-contents navigation implementation')
 
 required = [
@@ -88,11 +96,14 @@ required = [
     'obj.textContent = end;',
     'requestAnimationFrame(step);',
     "behavior: reduceMotion ? 'auto' : 'smooth'",
+    'top: s.getBoundingClientRect().top + window.scrollY - getStickyOffset()',
 ]
 missing = [snippet for snippet in required if snippet not in text]
 if missing:
     raise SystemExit(f'Reduced-motion policy is incomplete: {missing}')
 if text.count("behavior: reduceMotion ? 'auto' : 'smooth'") < 2:
     raise SystemExit('Reduced-motion policy must cover both TOC and sticky section navigation')
+if text.count('getStickyOffset()') < 3:
+    raise SystemExit('Sticky offset must cover deep links, TOC, and sticky section navigation')
 
 path.write_text(text, encoding='utf-8')

--- a/scripts/maintain_reduced_motion.py
+++ b/scripts/maintain_reduced_motion.py
@@ -96,14 +96,14 @@ required = [
     'obj.textContent = end;',
     'requestAnimationFrame(step);',
     "behavior: reduceMotion ? 'auto' : 'smooth'",
+    'top: target.getBoundingClientRect().top + window.scrollY - getStickyOffset()',
     'top: s.getBoundingClientRect().top + window.scrollY - getStickyOffset()',
+    'top: section.getBoundingClientRect().top + window.scrollY - getStickyOffset()',
 ]
 missing = [snippet for snippet in required if snippet not in text]
 if missing:
-    raise SystemExit(f'Reduced-motion policy is incomplete: {missing}')
+    raise SystemExit(f'Reduced-motion or sticky-offset policy is incomplete: {missing}')
 if text.count("behavior: reduceMotion ? 'auto' : 'smooth'") < 2:
     raise SystemExit('Reduced-motion policy must cover both TOC and sticky section navigation')
-if text.count('getStickyOffset()') < 3:
-    raise SystemExit('Sticky offset must cover deep links, TOC, and sticky section navigation')
 
 path.write_text(text, encoding='utf-8')


### PR DESCRIPTION
Closes #194.

## What changed
- Reuse `getStickyOffset()` for floating TOC jumps instead of subtracting only the fixed header height.
- Preserve the existing reduced-motion behavior.
- Extend deterministic maintenance checks so TOC, deep-link, and sticky-section navigation continue to account for the sticky controls.

## Why
The TOC and sticky section tabs navigate to the same sections. They should not land at different vertical positions, especially when the sticky section navigation can cover a heading.

No visual decoration or content changes are included.