### PR TITLE
Gate post-optimization validation on upstream success

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   validate:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Closes #209.

## What changed
- Run the post-optimization validation job only after `Optimize Portfolio Assets` succeeds.
- Keep `workflow_dispatch` available for manual validation.

## Why
A failed optimization run previously still triggered validation against the latest `main`, so unchanged content could receive a green downstream validation even though the update step failed. This makes the dependency explicit without changing portfolio content or styling.

## Scope
One workflow condition only; no site content, navigation, or visual changes.