### PR TITLE
Pin validation to Python 3.14

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,6 +23,10 @@ jobs:
           ref: main
           persist-credentials: false
           fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
       - name: Validate deployable portfolio essentials
         run: |
           for path in \


### PR DESCRIPTION
## Summary

Use the same explicit Python 3.14 runtime for post-optimization validation that the optimization workflow already uses.

## Why

Generation and validation currently run the same maintenance scripts under different Python environments. Pinning validation removes runner-image drift as a source of unrelated CI failures.

## Scope

- add the pinned `actions/setup-python` action to `static.yml`
- use Python 3.14
- leave all validation steps and Pages deployment ownership unchanged

Closes #211