### PR TITLE
Restore deployed security contact verification

### DIFF
--- a/.github/workflows/security-contact-check.yml
+++ b/.github/workflows/security-contact-check.yml
@@ -14,9 +14,6 @@ on:
       - 'SECURITY.md'
       - 'scripts/check_security_contact.py'
       - '.github/workflows/security-contact-check.yml'
-  workflow_run:
-    workflows: ['Deploy static content to Pages']
-    types: [completed]
   schedule:
     - cron: '17 0 * * 1'
   workflow_dispatch:
@@ -35,18 +32,26 @@ jobs:
       - name: Validate security contact metadata
         run: python scripts/check_security_contact.py
       - name: Verify deployed security contact
-        if: >-
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           url='https://sakai1250.github.io/.well-known/security.txt'
-          curl --fail --silent --show-error --location \
-            --retry 3 --retry-delay 5 --retry-all-errors --max-time 20 \
-            "$url" --output deployed-security.txt
-          cmp --silent .well-known/security.txt deployed-security.txt || {
-            echo 'Deployed security.txt does not match the repository copy.'
-            diff -u .well-known/security.txt deployed-security.txt || true
-            exit 1
-          }
-          echo 'OK: deployed security.txt is reachable and matches main'
+          deployed_file='deployed-security.txt'
+
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error --location \
+              --retry 2 --retry-delay 3 --retry-all-errors --max-time 20 \
+              "$url" --output "$deployed_file" && \
+              cmp --silent .well-known/security.txt "$deployed_file"; then
+              echo 'OK: deployed security.txt is reachable and matches main'
+              exit 0
+            fi
+
+            if [[ "$attempt" -lt 12 ]]; then
+              echo "Deployed security.txt does not match main yet; retrying ($attempt/12)."
+              sleep 10
+            fi
+          done
+
+          echo 'Deployed security.txt did not match the repository copy before the retry limit.'
+          diff -u .well-known/security.txt "$deployed_file" || true
+          exit 1


### PR DESCRIPTION
## Summary

Fix the security contact workflow after Pages publication moved away from the removed `Deploy static content to Pages` workflow.

## Changes

- remove the stale `workflow_run` dependency
- verify the deployed `.well-known/security.txt` on relevant pushes, scheduled runs, and manual runs
- keep pull requests local-only
- retry the live comparison for up to roughly two minutes so normal GitHub Pages propagation does not create an immediate false failure
- fail with a diff if the deployed file never matches the repository copy

Closes #213