### PR TITLE
Pin remaining validation workflows to Python 3.14

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -39,6 +39,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
 
       - name: Check external links
         run: python scripts/check_external_links.py

--- a/.github/workflows/progressive-enhancement.yml
+++ b/.github/workflows/progressive-enhancement.yml
@@ -29,5 +29,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
       - name: Verify portfolio is visible without JavaScript
-        run: python3 scripts/check_progressive_enhancement.py
+        run: python scripts/check_progressive_enhancement.py

--- a/.github/workflows/security-contact-check.yml
+++ b/.github/workflows/security-contact-check.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
       - name: Validate security contact metadata
         run: python scripts/check_security_contact.py
       - name: Verify deployed security contact

--- a/.github/workflows/static-fallbacks.yml
+++ b/.github/workflows/static-fallbacks.yml
@@ -31,10 +31,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
 
       - name: Validate visible fallback metadata
         run: |
-          python3 scripts/maintain_static_fallbacks.py
+          python scripts/maintain_static_fallbacks.py
           if ! git diff --exit-code -- index.html sitemap.xml; then
             echo 'Static fallback metadata is stale. Run scripts/run_deterministic_maintenance.py and commit the result.'
             exit 1

--- a/.github/workflows/tab-maintenance-check.yml
+++ b/.github/workflows/tab-maintenance-check.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
-          python-version: '3.x'
+          python-version: '3.14'
       - name: Validate maintenance scripts
         run: |
           python scripts/run_deterministic_maintenance.py --compile-only


### PR DESCRIPTION
## Summary

Pin the remaining Python-based validation workflows to the same explicit Python 3.14 runtime already used by optimization, structured-profile, site-integrity, and post-optimization validation.

## Changes

- add commit-pinned `actions/setup-python` with Python 3.14 to External Link Check
- add the same runtime to Progressive enhancement check
- add the same runtime to Security contact check
- add the same runtime to Keep static fallbacks aligned
- replace floating `3.x` with `3.14` in Interaction maintenance check

No validation rules, triggers, permissions, portfolio content, or visual behavior are changed.

Closes #215