### PR TITLE
Add stable recruiter deep links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Personal portfolio for Taigo Sakai, a Ph.D. student, Special Assistant, computer
 - **Portfolio:** https://sakai1250.github.io
 - **Research:** https://sakai1250.github.io/#research-content
 - **Research achievements:** https://sakai1250.github.io/#research-research-achievements
+- **Education:** https://sakai1250.github.io/#research-education
 - **Awards:** https://sakai1250.github.io/#research-awards
+- **Internship:** https://sakai1250.github.io/#research-internship
 - **Engineering:** https://sakai1250.github.io/#engineer-content
 - **Apps & services:** https://sakai1250.github.io/#engineer-my-apps-and-services
 - **CV:** https://sakai1250.github.io/assets/cv.pdf

--- a/scripts/maintain_tab_deep_links.py
+++ b/scripts/maintain_tab_deep_links.py
@@ -9,7 +9,9 @@ html = html_path.read_text(encoding="utf-8")
 
 static_section_ids = {
     "Research Achievements": "research-research-achievements",
+    "Education": "research-education",
     "Awards": "research-awards",
+    "Internship": "research-internship",
     "My Apps & Services": "engineer-my-apps-and-services",
 }
 

--- a/scripts/prepare_header_section_reordering.py
+++ b/scripts/prepare_header_section_reordering.py
@@ -12,7 +12,9 @@ INDEX = ROOT / "index.html"
 
 STATIC_SECTION_IDS = (
     "research-research-achievements",
+    "research-education",
     "research-awards",
+    "research-internship",
     "engineer-my-apps-and-services",
 )
 


### PR DESCRIPTION
## Summary

- assign static deploy-safe IDs to Education and Internship through the existing deterministic maintenance path
- preserve those IDs during section reordering
- expose both destinations from README quick links

## Why

Recruiters can reach education and internship history directly from the repository landing page instead of scanning the full Research section. Reusing the existing stable-ID maintenance keeps these links consistent with Research Achievements, Awards, and Apps without adding new JavaScript navigation behavior.

Closes #217