### PR TITLE
Stabilize generated homepage update dates

### DIFF
--- a/scripts/maintain_static_fallbacks.py
+++ b/scripts/maintain_static_fallbacks.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree as ET
 
 INDEX_PATH = Path("index.html")
 SITEMAP_PATH = Path("sitemap.xml")
-TRACKED_PAGE_FILES = ("index.html", "main.js", "style.css", "effects.js")
+TRACKED_PAGE_FILES = ("index.html", "main.js", "style.css", "effects.js", "scripts")
 HOME_URL = "https://sakai1250.github.io/"
 SITE_TIMEZONE = ZoneInfo("Asia/Tokyo")
 STATIC_SITEMAP_FILES = {


### PR DESCRIPTION
## Summary

- include deterministic maintenance sources in homepage update-date history
- keep resource-specific CV and `llms.txt` dates unchanged
- prevent generated page commits from advancing the footer/sitemap date only after the commit is created

## Why

The Education/Internship maintenance change exposed a date-boundary failure: optimization produced the correct generated page, then post-optimization validation immediately wanted a date-only follow-up diff. Including the maintenance source history makes the date known before generated output is committed and restores idempotence across the boundary.

Closes #219