### PR TITLE
Keep homepage dates tied to site-producing sources

### DIFF
--- a/scripts/maintain_static_fallbacks.py
+++ b/scripts/maintain_static_fallbacks.py
@@ -12,7 +12,16 @@ import xml.etree.ElementTree as ET
 
 INDEX_PATH = Path("index.html")
 SITEMAP_PATH = Path("sitemap.xml")
-TRACKED_PAGE_FILES = ("index.html", "main.js", "style.css", "effects.js", "scripts")
+# Track visitor-facing sources and the transforms that can change them. Validation-only
+# check_*.py edits should not make the public portfolio look newly updated.
+TRACKED_PAGE_FILES = (
+    "index.html",
+    "main.js",
+    "style.css",
+    "effects.js",
+    "scripts/maintain_*.py",
+    "scripts/run_deterministic_maintenance.py",
+)
 HOME_URL = "https://sakai1250.github.io/"
 SITE_TIMEZONE = ZoneInfo("Asia/Tokyo")
 STATIC_SITEMAP_FILES = {


### PR DESCRIPTION
## Summary

Narrow the homepage update-date source set so validation-only script changes do not make the public portfolio appear newly updated.

The footer and homepage sitemap `lastmod` still track visitor-facing files, deterministic `maintain_*.py` transforms, and the deterministic maintenance runner. They no longer track unrelated `check_*.py` edits through the whole `scripts/` directory.

## Why

This keeps the visible update date meaningful to researchers and recruiters while preserving the engineering safeguard that maintenance-source changes advance the generated date.

Closes #225