### PR TITLE
Enforce the full new-tab rel policy

### DIFF
--- a/scripts/check_new_tab_link_security.py
+++ b/scripts/check_new_tab_link_security.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 
 HTML_FILES = [Path('index.html'), Path('404.html')]
+REQUIRED_REL_TOKENS = {'noopener', 'noreferrer'}
 problems = []
 checked_links = 0
 
@@ -24,10 +25,12 @@ class LinkParser(HTMLParser):
 
         checked_links += 1
         rel_tokens = {token.lower() for token in attrs.get('rel', '').split()}
-        if 'noopener' not in rel_tokens:
+        missing_tokens = sorted(REQUIRED_REL_TOKENS - rel_tokens)
+        if missing_tokens:
             href = attrs.get('href', '<missing href>')
+            missing = ' '.join(missing_tokens)
             problems.append(
-                f'{self.path}: target="_blank" link is missing rel="noopener": {href}'
+                f'{self.path}: target="_blank" link is missing rel token(s) {missing}: {href}'
             )
 
 
@@ -42,4 +45,7 @@ for html_path in HTML_FILES:
 if problems:
     raise SystemExit('\n'.join(problems))
 
-print(f'OK: {checked_links} new-tab links include rel="noopener"')
+print(
+    f'OK: {checked_links} new-tab links include '
+    'rel="noopener noreferrer"'
+)


### PR DESCRIPTION
## Summary

- require both `noopener` and `noreferrer` for every `target="_blank"` link
- report the exact missing rel token(s) and URL
- keep the validation local and network-free

## Why

The deterministic HTML maintenance already emits `rel="noopener noreferrer"`, but the validator only enforced `noopener`. This PR makes the validation contract match the published markup policy and prevents silent regressions.

Closes #227