### PR TITLE
Validate externally hosted portfolio images

### DIFF
--- a/scripts/check_external_links.py
+++ b/scripts/check_external_links.py
@@ -28,11 +28,14 @@ class LinkParser(HTMLParser):
         self.links = set()
 
     def handle_starttag(self, tag, attrs):
-        if tag != "a":
-            return
-        href = dict(attrs).get("href", "")
-        if href.startswith(("http://", "https://")):
-            self.links.add(href)
+        attrs = dict(attrs)
+        url = ""
+        if tag == "a":
+            url = attrs.get("href", "")
+        elif tag == "img":
+            url = attrs.get("src", "")
+        if url.startswith(("http://", "https://")):
+            self.links.add(url)
 
 
 def hostname(url):
@@ -127,7 +130,7 @@ def main():
     }
 
     failures = []
-    print(f"Checking {len(links)} external links")
+    print(f"Checking {len(links)} external links and images")
 
     for url in sorted(links):
         success, status, error = check_url(url)
@@ -138,7 +141,7 @@ def main():
             print(f"OK   {status}: {url}")
 
     if failures:
-        raise SystemExit(f"{len(failures)} external link(s) are broken or unreachable")
+        raise SystemExit(f"{len(failures)} external link(s) or image(s) are broken or unreachable")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- collect external `<img src>` URLs from `index.html` and `404.html` in the existing external-resource check
- keep the existing retry, HEAD/GET fallback, deployment-host handling, and automation-block response handling unchanged
- make failure output cover both navigation links and images

## Why

A dead externally hosted app thumbnail or badge is visible portfolio breakage even when every `<a href>` still works. This closes the gap tracked in #229 without changing the visible site.

Closes #229