### PR TITLE
Reserve intrinsic space for app thumbnails

### DIFF
--- a/scripts/maintain_app_thumbnail_dimensions.py
+++ b/scripts/maintain_app_thumbnail_dimensions.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Keep app thumbnails dimensioned so lazy external images do not shift layout."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+path = Path("index.html")
+text = path.read_text(encoding="utf-8")
+pattern = re.compile(r'<img\b[^>]*\bclass="app-thumb"[^>]*>')
+
+
+def add_intrinsic_size(match: re.Match[str]) -> str:
+    tag = match.group(0)
+    has_width = re.search(r'\bwidth="\d+"', tag) is not None
+    has_height = re.search(r'\bheight="\d+"', tag) is not None
+    if has_width and has_height:
+        return tag
+    if has_width != has_height:
+        raise SystemExit(f"App thumbnail has only one intrinsic dimension: {tag}")
+    if ' loading="lazy"' not in tag:
+        raise SystemExit(f"App thumbnail is missing lazy loading marker: {tag}")
+    return tag.replace(
+        ' loading="lazy"',
+        ' width="82" height="82" loading="lazy"',
+        1,
+    )
+
+
+matches = pattern.findall(text)
+if not matches:
+    raise SystemExit("Could not find app thumbnails")
+
+text = pattern.sub(add_intrinsic_size, text)
+
+for tag in pattern.findall(text):
+    if 'width="82"' not in tag or 'height="82"' not in tag:
+        raise SystemExit(f"App thumbnail intrinsic size drifted: {tag}")
+
+path.write_text(text, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -17,6 +17,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_contact_form.py",
     "scripts/prepare_header_section_reordering.py",
     "scripts/maintain_header_controls.py",
+    "scripts/maintain_app_thumbnail_dimensions.py",
     "scripts/maintain_tab_deep_links.py",
     "scripts/maintain_header_stat_links.py",
     "scripts/maintain_filter_accessibility.py",


### PR DESCRIPTION
Closes #231.

## What changed
- add a deterministic maintenance step that gives every `.app-thumb` image `width="82"` and `height="82"`
- keep the existing responsive CSS, lazy loading, empty alt text, image URLs, and modal behavior unchanged
- include the new transform in the standard deterministic maintenance runner

## Why
The app images are external and lazy-loaded. Declaring their square intrinsic size lets the browser reserve the correct aspect ratio before the image arrives, reducing avoidable layout movement in the Apps section.

## Review scope
This is a layout-stability/maintenance change only. It adds no decoration, new navigation, or JavaScript behavior.