### PR TITLE
Require primary sources in sitemap validation

### DIFF
--- a/scripts/check_site_integrity.py
+++ b/scripts/check_site_integrity.py
@@ -198,6 +198,17 @@ if sitemap.exists():
         locs = [node.text.strip() for node in tree.findall('.//sm:loc', ns) if node.text]
         if not locs:
             problems.append('sitemap.xml: no <loc> entries')
+        required_locs = {
+            'https://sakai1250.github.io/',
+            'https://sakai1250.github.io/assets/cv.pdf',
+            'https://sakai1250.github.io/assets/cv.txt',
+            'https://sakai1250.github.io/llms.txt',
+        }
+        missing_locs = sorted(required_locs.difference(locs))
+        if missing_locs:
+            problems.append(
+                f'sitemap.xml: missing required primary URLs {missing_locs}'
+            )
         for loc in locs:
             parsed = urlsplit(loc)
             if parsed.netloc != 'sakai1250.github.io':


### PR DESCRIPTION
## Summary

- require the homepage, PDF CV, machine-readable CV, and `llms.txt` to remain present in `sitemap.xml`
- keep the existing host and local-target validation unchanged
- fail with an explicit list when a primary sitemap URL is missing

## Why

The previous check validated only URLs that were already listed. A primary source could be removed from the sitemap accidentally while CI still passed. This closes that gap for researcher, recruiter, and machine-readable navigation without changing visible content.

Closes #233