### PR TITLE
Remove duplicate accessibility mutations from effects.js

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -17,62 +17,6 @@ function initTypingEffect() {
     if (cursor) cursor.style.display = 'none';
 }
 
-function getSectionByEnglishTitle(title) {
-    return Array.from(document.querySelectorAll('.section-card')).find(section => {
-        const heading = section.querySelector('.section-title [lang="en"]');
-        return heading?.textContent.trim() === title;
-    });
-}
-
-function initPublicationLinkAccessibility() {
-    const researchSection = getSectionByEnglishTitle('Research Achievements');
-    if (!researchSection) return;
-
-    researchSection.querySelectorAll('.repo-list > li').forEach(item => {
-        const link = Array.from(item.querySelectorAll('a')).find(anchor => {
-            const label = anchor.textContent.trim();
-            return label === '[Paper]' || label === '[Program]';
-        });
-        if (!link) return;
-
-        const rawText = item.textContent.replace(/\s+/g, ' ').trim();
-        const titleMatch = rawText.match(/[“"]\s*([^”"]+?)\s*[,”"]/);
-        if (!titleMatch) return;
-
-        const resource = link.textContent.trim().slice(1, -1);
-        link.setAttribute('aria-label', `${resource}: ${titleMatch[1].trim()}`);
-    });
-}
-
-function initAppResourceLinkAccessibility() {
-    document.querySelectorAll('.app-card').forEach(card => {
-        const title = card.querySelector('.app-title')?.textContent.replace(/\s+/g, ' ').trim();
-        if (!title) return;
-
-        card.querySelectorAll('.app-links a').forEach(link => {
-            const resource = link.textContent.replace(/\s+/g, ' ').trim();
-            if (!resource) return;
-            link.setAttribute('aria-label', `${resource}: ${title}`);
-        });
-    });
-}
-
-function initTocAccessibility() {
-    const button = document.getElementById('toc-fab');
-    const menu = document.getElementById('toc-menu');
-    if (!button || !menu) return;
-
-    button.setAttribute('aria-controls', 'toc-menu');
-    const sync = () => {
-        button.setAttribute('aria-expanded', String(menu.classList.contains('show')));
-    };
-    sync();
-
-    const observer = new MutationObserver(sync);
-    observer.observe(menu, { attributes: true, attributeFilter: ['class'] });
-    window.addEventListener('pagehide', () => observer.disconnect(), { once: true });
-}
-
 function initPortfolioPolish() {
     if (document.getElementById('portfolio-polish-style')) return;
 
@@ -134,10 +78,6 @@ function initPortfolioPolish() {
         if (tab.dataset.tab === 'research') ja.textContent = '研究';
         if (tab.dataset.tab === 'engineer') ja.textContent = '開発';
     });
-
-    initPublicationLinkAccessibility();
-    initAppResourceLinkAccessibility();
-    initTocAccessibility();
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- remove runtime publication-link accessible-name rewriting from `effects.js`
- remove runtime App-link accessible-name rewriting from `effects.js`
- remove the duplicate TOC `MutationObserver` and ARIA state synchronization from `effects.js`

The static HTML already carries contextual resource-link `aria-label` values, and `main.js` already owns TOC `aria-controls` / `aria-expanded` state.

## Impact
No visible styling or navigation changes. This reduces duplicate accessibility logic and leaves each behavior with one owner.

Closes #237