### PR TITLE
Reduce duplicate runtime portfolio mutations

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -20,64 +20,23 @@ function initTypingEffect() {
 function initPortfolioPolish() {
     if (document.getElementById('portfolio-polish-style')) return;
 
+    // Keep only the desktop adjustment that is not already represented in static CSS.
     const style = document.createElement('style');
     style.id = 'portfolio-polish-style';
     style.textContent = `
-        .header-profile::before,
-        .header-profile::after,
-        .avatar-drag-tooltip {
-            display: none !important;
-        }
-
         @media (min-width: 769px) {
             .header-stats {
                 transform: translate(-50%, -8px) !important;
             }
         }
-
-        @media (max-width: 768px) {
-            .header-actions a[href="assets/cv.pdf"] { display: inline-flex !important; }
-            .header-tab-row .year-filter {
-                flex-wrap: nowrap !important;
-                overflow-x: auto;
-                padding-bottom: 4px;
-                scrollbar-width: none;
-            }
-            .header-tab-row .year-filter::-webkit-scrollbar { display: none; }
-            .header-tab-row .year-filter .filter-label,
-            .header-tab-row .year-filter .chip {
-                flex: 0 0 auto;
-            }
-            .header-tab-row .year-filter .filter-label { width: auto !important; }
-            .header-tab-row .year-filter .chip { min-height: 36px; }
-        }
     `;
     document.head.appendChild(style);
 
-    const paperStat = document.querySelector('#stat-papers')?.closest('.stat-item');
-    const jaStatLabel = paperStat?.querySelector('.stat-label [lang="ja"]');
-    const enStatLabel = paperStat?.querySelector('.stat-label [lang="en"]');
-    if (jaStatLabel) jaStatLabel.textContent = '研究業績';
-    if (enStatLabel) enStatLabel.textContent = 'Research outputs';
-
+    // Keep the current call-to-action priority until it is moved into static HTML.
     const cvButton = document.querySelector('.header-actions a[href="assets/cv.pdf"]');
     const githubButton = document.querySelector('.header-actions a[href*="github.com/sakai1250"]');
     cvButton?.classList.add('primary');
     githubButton?.classList.remove('primary');
-
-    if (githubButton) {
-        const ja = githubButton.querySelector('[lang="ja"]');
-        const en = githubButton.querySelector('[lang="en"]');
-        if (ja) ja.textContent = 'GitHub';
-        if (en) en.textContent = 'GitHub';
-    }
-
-    document.querySelectorAll('.tab-item').forEach(tab => {
-        const ja = tab.querySelector('[lang="ja"]');
-        if (!ja) return;
-        if (tab.dataset.tab === 'research') ja.textContent = '研究';
-        if (tab.dataset.tab === 'engineer') ja.textContent = '開発';
-    });
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
Remove runtime DOM/CSS mutations from `effects.js` that duplicate state already present in static HTML/CSS.

## What changed
- Removed repeated rewriting of the research-output label, GitHub label, and Research/Engineering labels; the static HTML already contains the intended text.
- Removed injected mobile year-filter, decorative-element, and CV display rules that are already represented by `style.css` or the base `.header-btn` rule.
- Kept only the desktop header-stat offset and the CV/GitHub primary-action swap because those still differ from the current static source and need a separate static-source migration.
- Kept compatibility no-op exports and `initTypingEffect()` for older cached `main.js` versions.

## Why
This reduces two-source-of-truth behavior without changing the rendered result, and makes the remaining work in #241 explicit rather than mixing static and runtime ownership silently.

Related to #241.