### PR TITLE
Stop effects.js from overriding profile role

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -9,11 +9,7 @@ function initCardDragRotation() {}
 function initBackgroundParticles() {}
 
 function initTypingEffect() {
-    const textElement = document.getElementById('typing-text');
     const cursor = document.querySelector('.typing-container .cursor');
-    if (!textElement) return;
-
-    textElement.textContent = 'Ph.D. Student · Special Assistant · Computer Vision Researcher';
     if (cursor) cursor.style.display = 'none';
 }
 


### PR DESCRIPTION
## Summary
Remove the duplicate hard-coded role assignment from `effects.js` while keeping the existing cursor cleanup and compatibility exports unchanged.

## Why
The role is already present in static HTML. Rewriting it again at runtime creates a drift risk: a future profile update could be correct in `index.html` but be reverted to an older value when JavaScript runs.

## Impact
- Researcher/recruiter-facing role text remains unchanged today.
- Future role updates have one less runtime source that can silently override the static profile.
- No visual decoration is added or changed beyond keeping the existing cursor hidden.

## Follow-up
Issue #246 tracks removing the now-obsolete `effects.js` dependency completely once all runtime, maintenance, and workflow references are removed together.