### PR TITLE
Stop maintenance from tracking the obsolete effects shim

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -66,7 +66,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "chore: update portfolio assets and optimized images"
-          file_pattern: "assets/* index.html 404.html main.js effects.js style.css sitemap.xml"
+          file_pattern: "assets/* index.html 404.html main.js style.css sitemap.xml"
           commit_user_name: "sakai1250"
           commit_user_email: "92532910+sakai1250@users.noreply.github.com"
           commit_author: "sakai1250 <92532910+sakai1250@users.noreply.github.com>"

--- a/.github/workflows/site-integrity.yml
+++ b/.github/workflows/site-integrity.yml
@@ -23,9 +23,7 @@ jobs:
         with:
           node-version: '24'
       - name: Check JavaScript syntax
-        run: |
-          node --check main.js
-          node --check effects.js
+        run: node --check main.js
       - name: Check links, accessibility basics, generated data, CV text, and indexing files
         run: python scripts/check_site_integrity.py
       - name: Check interactive control names

--- a/.github/workflows/static-fallbacks.yml
+++ b/.github/workflows/static-fallbacks.yml
@@ -6,7 +6,6 @@ on:
       - 'index.html'
       - 'main.js'
       - 'style.css'
-      - 'effects.js'
       - 'sitemap.xml'
       - 'scripts/maintain_static_fallbacks.py'
       - 'scripts/run_deterministic_maintenance.py'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,7 +38,6 @@ jobs:
             404.html \
             style.css \
             main.js \
-            effects.js \
             robots.txt \
             sitemap.xml \
             assets/cv.pdf \
@@ -51,9 +50,7 @@ jobs:
             fi
           done
       - name: Validate JavaScript syntax
-        run: |
-          node --check main.js
-          node --check effects.js
+        run: node --check main.js
       - name: Validate site integrity
         run: python scripts/check_site_integrity.py
       - name: Validate interactive accessible names
@@ -83,7 +80,7 @@ jobs:
       - name: Validate full interaction maintenance
         run: |
           python scripts/run_deterministic_maintenance.py
-          git diff --exit-code -- index.html 404.html main.js effects.js style.css
+          git diff --exit-code -- index.html 404.html main.js style.css
       - name: Validate static fallback metadata
         run: |
           python scripts/maintain_static_fallbacks.py

--- a/.github/workflows/tab-maintenance-check.yml
+++ b/.github/workflows/tab-maintenance-check.yml
@@ -30,7 +30,7 @@ jobs:
             python scripts/run_deterministic_maintenance.py
           }
 
-          tracked_site_files=(index.html 404.html main.js effects.js style.css sitemap.xml)
+          tracked_site_files=(index.html 404.html main.js style.css sitemap.xml)
           first_diff="$(mktemp)"
           second_diff="$(mktemp)"
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ python3.14 scripts/check_security_contact.py
 python3.14 scripts/check_structured_profile.py
 python3.14 scripts/check_llms_profile.py
 python3.14 scripts/check_year_filter_coverage.py
-git diff --exit-code -- index.html 404.html main.js effects.js style.css sitemap.xml
+git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml
 ```
 
 If the final command reports changes, include the generated maintenance updates in the same branch before pushing.

--- a/scripts/maintain_static_fallbacks.py
+++ b/scripts/maintain_static_fallbacks.py
@@ -18,7 +18,6 @@ TRACKED_PAGE_FILES = (
     "index.html",
     "main.js",
     "style.css",
-    "effects.js",
     "scripts/maintain_*.py",
     "scripts/run_deterministic_maintenance.py",
 )


### PR DESCRIPTION
## Summary
- stop CI and post-optimization validation from syntax-checking `effects.js`
- remove `effects.js` from deterministic maintenance, fallback-date tracking, fallback path triggers, and generated-file commit patterns
- align the README local validation command with the active site assets

## Why
`effects.js` is now a frozen compatibility shim rather than an active source of portfolio behavior. Keeping maintenance and CI centered on it makes the repository imply that it is still a maintained JavaScript responsibility and adds work that cannot improve the visible site.

This is a scoped step toward #246. It intentionally leaves the runtime script request and the two compatibility calls in `main.js` unchanged for now, so cached-page compatibility is not removed in the same change as the maintenance cleanup.

## Visitor impact
No visible portfolio content, navigation, or styling changes.

## Review focus
- deterministic maintenance still tracks all active generated site files
- deploy validation still checks `main.js` with Node 24
- fallback update dates no longer move because of changes to a compatibility-only shim

Closes part of #246.