### PR TITLE
Trim obsolete effects shim API

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -1,11 +1,8 @@
 /**
- * Taigo Sakai Portfolio - Restrained visual details
+ * Taigo Sakai Portfolio - Temporary compatibility shim
  */
 
-// Kept as no-ops for compatibility with older cached main.js versions.
-function init3DEffects() {}
-function initAvatarDragGuide() {}
-function initCardDragRotation() {}
+// Kept only for older cached main.js versions until this file is removed.
 function initBackgroundParticles() {}
 
 function initTypingEffect() {
@@ -13,9 +10,5 @@ function initTypingEffect() {
     if (cursor) cursor.style.display = 'none';
 }
 
-
-window.init3DEffects = init3DEffects;
 window.initBackgroundParticles = initBackgroundParticles;
 window.initTypingEffect = initTypingEffect;
-window.initAvatarDragGuide = initAvatarDragGuide;
-window.initCardDragRotation = initCardDragRotation;


### PR DESCRIPTION
## Summary
Remove three no-op `effects.js` exports that are no longer referenced anywhere in the repository: `init3DEffects`, `initAvatarDragGuide`, and `initCardDragRotation`.

## Why
- Researcher/recruiter: no visible content or navigation change.
- Engineer: reduces dead compatibility API surface and narrows the remaining shim to the two functions still called by older/current `main.js` paths while Issue #246 tracks full removal.

## Validation
- Repository search shows the removed names existed only in `effects.js`.
- The two remaining compatibility exports are unchanged.

Related to #246.