### PR TITLE
Remove obsolete background effects compatibility path

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -3,12 +3,9 @@
  */
 
 // Kept only for older cached main.js versions until this file is removed.
-function initBackgroundParticles() {}
-
 function initTypingEffect() {
     const cursor = document.querySelector('.typing-container .cursor');
     if (cursor) cursor.style.display = 'none';
 }
 
-window.initBackgroundParticles = initBackgroundParticles;
 window.initTypingEffect = initTypingEffect;

--- a/main.js
+++ b/main.js
@@ -28,8 +28,6 @@ document.addEventListener('DOMContentLoaded', () => {
     safeInit(initReadingProgress, 'ReadingProgress');
     safeInit(initContextualShareLink, 'ContextualShareLink');
 
-    // Visual Effects (From effects.js)
-    safeInit(window.initBackgroundParticles, 'BackgroundParticles');
     safeInit(window.initTypingEffect, 'TypingEffect');
 });
 


### PR DESCRIPTION
## Summary
- remove the no-op `initBackgroundParticles` export from `effects.js`
- stop `main.js` from looking up and initializing that obsolete function
- leave the temporary typing cursor compatibility behavior unchanged

## Why
This narrows Issue #246 to the only behavior the shim still performs. The background initializer has no implementation and no visible effect, so keeping its global API and startup lookup only makes the JavaScript ownership harder to understand.

## Impact
- Researcher/recruiter: no visible content or navigation change
- Engineer: removes one dead global export and one dead initialization path

## Validation
- diff is limited to two deletions in `main.js` and three deletions in `effects.js`
- no portfolio content, URLs, or styling changed

Refs #246