### PR TITLE
Keep primary tab ARIA state synchronized

### DIFF
--- a/main.js
+++ b/main.js
@@ -73,6 +73,7 @@ function initTabs() {
         const id = i.getAttribute('data-tab');
         i.setAttribute('role', 'tab');
         i.setAttribute('aria-controls', `${id}-content`);
+        i.removeAttribute('aria-current');
     });
     tabContents.forEach(c => {
         c.setAttribute('role', 'tabpanel');

--- a/scripts/check_progressive_enhancement.py
+++ b/scripts/check_progressive_enhancement.py
@@ -110,6 +110,10 @@ if parser.primary_tab_aria_current.get("research-tab") != "true":
     problems.append('Research primary navigation must expose aria-current="true" in static HTML.')
 if parser.primary_tab_aria_current.get("engineer-tab") is not None:
     problems.append("Engineering primary navigation must not expose aria-current by default in static HTML.")
+if "i.removeAttribute('aria-current');" not in main:
+    problems.append(
+        "Enhanced primary tabs must remove static aria-current before exposing aria-selected state."
+    )
 
 for element_id in ("toc-fab", "toc-menu"):
     if parser.toc_hidden.get(element_id) is not True:


### PR DESCRIPTION
## Summary
- remove the static `aria-current` marker when the Research / Engineering links are upgraded into runtime ARIA tabs
- keep `aria-selected` as the single active-state signal after enhancement
- extend the progressive-enhancement check so this state handoff cannot silently regress

## Why
The static links intentionally expose Research as the current destination when JavaScript is unavailable. After `initTabs()` assigns `role="tab"`, leaving that static marker in place conflicts with the runtime `aria-selected` state when users switch to Engineering.

This keeps the no-JavaScript navigation usable while giving assistive technology one unambiguous state model after enhancement.

Fixes #252