### PR TITLE
Keep security contact aligned with public profile

### DIFF
--- a/.github/workflows/security-contact-check.yml
+++ b/.github/workflows/security-contact-check.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - '.well-known/security.txt'
       - 'SECURITY.md'
+      - 'assets/cv.txt'
       - 'scripts/check_security_contact.py'
       - '.github/workflows/security-contact-check.yml'
   pull_request:
     paths:
       - '.well-known/security.txt'
       - 'SECURITY.md'
+      - 'assets/cv.txt'
       - 'scripts/check_security_contact.py'
       - '.github/workflows/security-contact-check.yml'
   schedule:

--- a/scripts/check_security_contact.py
+++ b/scripts/check_security_contact.py
@@ -2,6 +2,7 @@
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from urllib.parse import urlsplit
+import re
 
 
 def main() -> None:
@@ -34,6 +35,25 @@ def main() -> None:
     if not any(value.startswith(('mailto:', 'https://')) for value in contacts):
         raise SystemExit('Contact must include a mailto: or https:// URI')
 
+    cv_text = Path('assets/cv.txt').read_text(encoding='utf-8')
+    cv_email_match = re.search(r'^Email:\s*(\S+@\S+)\s*$', cv_text, flags=re.MULTILINE)
+    if not cv_email_match:
+        raise SystemExit('assets/cv.txt is missing a machine-readable Email field')
+    profile_email = cv_email_match.group(1)
+    expected_mailto = f'mailto:{profile_email}'
+    if expected_mailto not in contacts:
+        raise SystemExit(
+            'security.txt Contact is out of sync with assets/cv.txt: '
+            f'expected {expected_mailto}'
+        )
+
+    policy_text = Path('SECURITY.md').read_text(encoding='utf-8')
+    if profile_email not in policy_text:
+        raise SystemExit(
+            'SECURITY.md is out of sync with the profile contact email: '
+            f'expected {profile_email}'
+        )
+
     expires_raw = fields['Expires'][0]
     try:
         expires = datetime.fromisoformat(expires_raw.replace('Z', '+00:00'))
@@ -54,7 +74,9 @@ def main() -> None:
     if policy and not all(urlsplit(value).scheme == 'https' for value in policy):
         raise SystemExit('Policy URLs must use HTTPS')
 
-    print(f'OK: security.txt valid through {expires.isoformat()}')
+    print(
+        f'OK: security.txt matches the public profile contact and is valid through {expires.isoformat()}'
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- validate that `.well-known/security.txt` uses the same contact email as `assets/cv.txt`
- validate that `SECURITY.md` documents that same email
- run the security-contact workflow whenever the machine-readable CV changes

## Why
The public profile already keeps the main portfolio, CV, and contact routes aligned, but the security contact could drift independently. A stale vulnerability-report address is a practical reliability problem even when the rest of the portfolio remains correct.

## Impact by audience
- **Researcher:** keeps the professional contact identity consistent across public sources.
- **Recruiter:** avoids conflicting contact details across profile documents.
- **Engineer:** prevents vulnerability reports from being routed to an obsolete address after a profile-email change.

## Scope
No visible layout, navigation, or decorative changes. This only strengthens validation and its trigger coverage.

## Validation
The existing `Security contact check` workflow exercises the updated script on this PR.