### PR TITLE
Validate README maintenance output

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Validate full interaction maintenance
         run: |
           python scripts/run_deterministic_maintenance.py
-          git diff --exit-code -- index.html 404.html main.js style.css
+          git diff --exit-code -- index.html 404.html main.js style.css README.md
       - name: Validate static fallback metadata
         run: |
           python scripts/maintain_static_fallbacks.py

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ python3.14 scripts/check_security_contact.py
 python3.14 scripts/check_structured_profile.py
 python3.14 scripts/check_llms_profile.py
 python3.14 scripts/check_year_filter_coverage.py
-git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml
+git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md
 ```
 
 If the final command reports changes, include the generated maintenance updates in the same branch before pushing.


### PR DESCRIPTION
## Why
`run_deterministic_maintenance.py` can update `README.md`, but both the post-optimization CI diff check and the documented local validation command omitted `README.md`. A maintenance transform could therefore change only the README without the clean-tree check noticing it.

## Changes
- Include `README.md` in the post-optimization deterministic maintenance diff check.
- Include `README.md` in the documented local validation diff command.

## Impact
No portfolio content or styling changes. This only makes maintenance drift easier to catch before merge/deployment.