### PR TITLE
Use machine-readable CV as profile link source

### DIFF
--- a/scripts/check_llms_profile.py
+++ b/scripts/check_llms_profile.py
@@ -30,6 +30,13 @@ def read_person_json_ld(index_text):
     raise SystemExit("index.html is missing Person JSON-LD")
 
 
+def read_cv_field(cv_text, label):
+    match = re.search(rf"^{re.escape(label)}:\s*(\S+)\s*$", cv_text, flags=re.MULTILINE)
+    if not match:
+        raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
+    return match.group(1)
+
+
 def main():
     llms_path = Path("llms.txt")
     cv_path = Path("assets/cv.txt")
@@ -71,21 +78,13 @@ def main():
     for route in required_routes:
         require(llms_text, route, "llms.txt")
 
-    cv_email_match = re.search(r"^Email:\s*(\S+@\S+)\s*$", cv_text, flags=re.MULTILINE)
-    if not cv_email_match:
-        raise SystemExit("assets/cv.txt is missing a machine-readable Email field")
-    contact_email = cv_email_match.group(1)
+    contact_email = read_cv_field(cv_text, "Email")
     contact_mailto = f"mailto:{contact_email}"
-    required_profiles = [
-        "https://github.com/sakai1250",
-        "https://qiita.com/sakai1250",
-        "https://www.linkedin.com/in/sakai1250",
-        "https://scholar.google.com/citations?user=eS-5wrQAAAAJ",
-    ]
+    profile_fields = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")
+    required_profiles = [read_cv_field(cv_text, label) for label in profile_fields]
     recovery_profiles = [
-        "https://github.com/sakai1250",
-        "https://www.linkedin.com/in/sakai1250",
-        "https://scholar.google.com/citations?user=eS-5wrQAAAAJ",
+        read_cv_field(cv_text, label)
+        for label in ("GitHub", "LinkedIn", "Google Scholar")
     ]
     for profile in required_profiles:
         require(llms_text, profile, "llms.txt")
@@ -100,9 +99,6 @@ def main():
     for item in shared_identity:
         require_casefold(cv_text, item, "assets/cv.txt")
     require(cv_text, "https://sakai1250.github.io/", "assets/cv.txt")
-
-    for profile in required_profiles:
-        require(cv_text, profile, "assets/cv.txt")
 
     # Human-facing recovery and contact routes must stay aligned with the
     # machine-readable profile so stale links do not survive on secondary pages.

--- a/scripts/check_structured_profile.py
+++ b/scripts/check_structured_profile.py
@@ -2,6 +2,10 @@
 from html.parser import HTMLParser
 from pathlib import Path
 import json
+import re
+
+
+PROFILE_FIELDS = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")
 
 
 class JsonLdParser(HTMLParser):
@@ -59,9 +63,17 @@ def single_value(values, label):
     return value
 
 
+def read_cv_field(cv_text, label):
+    match = re.search(rf"^{re.escape(label)}:\s*(\S+)\s*$", cv_text, flags=re.MULTILINE)
+    if not match:
+        raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
+    return match.group(1)
+
+
 def main():
     parser = JsonLdParser()
     parser.feed(Path("index.html").read_text(encoding="utf-8"))
+    cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
 
     people = []
     for raw in parser.blocks:
@@ -164,15 +176,13 @@ def main():
     if not isinstance(same_as, list):
         raise SystemExit("Person JSON-LD sameAs must be a list")
     required_profiles = {
-        "https://github.com/sakai1250",
-        "https://qiita.com/sakai1250",
-        "https://www.linkedin.com/in/sakai1250",
-        "https://scholar.google.com/citations?user=eS-5wrQAAAAJ",
+        read_cv_field(cv_text, label)
+        for label in PROFILE_FIELDS
     }
     missing_profiles = sorted(required_profiles - set(same_as))
     if missing_profiles:
         raise SystemExit(
-            f"Person JSON-LD is missing professional profile links: {missing_profiles}"
+            f"Person JSON-LD is missing professional profile links from assets/cv.txt: {missing_profiles}"
         )
 
     affiliation = person.get("affiliation")
@@ -188,7 +198,6 @@ def main():
             "Person JSON-LD uses alumniOf for a current affiliation; use affiliation instead"
         )
 
-    cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
     if person["name"].upper() not in cv_text.upper():
         raise SystemExit("assets/cv.txt is missing the JSON-LD person name")
     for required_role in required_roles:
@@ -198,14 +207,6 @@ def main():
         raise SystemExit("assets/cv.txt is missing the current affiliation")
     if person["url"] not in cv_text:
         raise SystemExit("assets/cv.txt is missing the canonical portfolio URL")
-    missing_cv_profiles = sorted(
-        profile for profile in required_profiles if profile not in cv_text
-    )
-    if missing_cv_profiles:
-        raise SystemExit(
-            "assets/cv.txt is missing professional profile links from JSON-LD: "
-            + ", ".join(missing_cv_profiles)
-        )
 
     print(
         "OK: public metadata, localized social previews, Person JSON-LD, and assets/cv.txt contain a consistent professional identity"

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -6,6 +6,15 @@ import re
 
 
 INDEX_PATH = Path("index.html")
+CV_PATH = Path("assets/cv.txt")
+PROFILE_FIELDS = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")
+
+
+def read_cv_field(cv_text: str, label: str) -> str:
+    match = re.search(rf"^{re.escape(label)}:\s*(\S+)\s*$", cv_text, flags=re.MULTILINE)
+    if not match:
+        raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
+    return match.group(1)
 
 
 def maintain_page_titles(text: str) -> str:
@@ -32,7 +41,7 @@ def maintain_page_titles(text: str) -> str:
     return text
 
 
-def maintain_structured_profile(text: str) -> str:
+def maintain_structured_profile(text: str, profile_urls: list[str]) -> str:
     old_title = '"jobTitle": "Ph.D. Student / Researcher / Engineer"'
     new_title = '"jobTitle": "Ph.D. Student / Special Assistant / Researcher / Engineer"'
     if old_title in text:
@@ -56,22 +65,13 @@ def maintain_structured_profile(text: str) -> str:
     elif new_context not in text:
         raise SystemExit("Could not find expected JSON-LD schema context")
 
-    scholar_url = "https://scholar.google.com/citations?user=eS-5wrQAAAAJ"
-    jsonld_start = text.find('<script type="application/ld+json">')
-    jsonld_end = text.find("</script>", jsonld_start)
-    if jsonld_start == -1 or jsonld_end == -1:
-        raise SystemExit("Could not find JSON-LD profile block")
-    jsonld = text[jsonld_start:jsonld_end]
-    if scholar_url not in jsonld:
-        marker = '      "https://www.linkedin.com/in/sakai1250"\n'
-        if marker not in jsonld:
-            raise SystemExit("Could not find JSON-LD profile-link insertion point")
-        text = text.replace(
-            marker,
-            '      "https://www.linkedin.com/in/sakai1250",\n'
-            f'      "{scholar_url}"\n',
-            1,
-        )
+    same_as_pattern = re.compile(r'("sameAs": \[\n)(.*?)(\n    \])', flags=re.DOTALL)
+    match = same_as_pattern.search(text)
+    if not match:
+        raise SystemExit("Could not find JSON-LD sameAs profile block")
+    desired_profiles = ",\n".join(f'      "{url}"' for url in profile_urls)
+    if match.group(2) != desired_profiles:
+        text = text[: match.start(2)] + desired_profiles + text[match.end(2) :]
 
     old_description = (
         "名城大学大学院 博士後期課程 坂井泰吾のポートフォリオ。"
@@ -143,8 +143,10 @@ def maintain_canonical_url(text: str) -> str:
 
 def main() -> None:
     text = INDEX_PATH.read_text(encoding="utf-8")
+    cv_text = CV_PATH.read_text(encoding="utf-8")
+    profile_urls = [read_cv_field(cv_text, label) for label in PROFILE_FIELDS]
     text = maintain_page_titles(text)
-    text = maintain_structured_profile(text)
+    text = maintain_structured_profile(text, profile_urls)
     text = maintain_visible_profile(text)
     text = maintain_canonical_url(text)
     INDEX_PATH.write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Why
Professional profile URLs are already listed in `assets/cv.txt`, but Google Scholar, LinkedIn, Qiita, and GitHub URLs were still duplicated inside profile validation and metadata maintenance scripts. A future profile URL update could therefore leave CI expecting an obsolete URL or make maintenance reinsert an old Scholar link.

## Changes
- derive required professional profile URLs in `check_llms_profile.py` from labeled fields in `assets/cv.txt`
- keep JSON-LD `sameAs` aligned with the same CV fields in `maintain_profile_metadata.py`
- validate JSON-LD profile links against the CV source in `check_structured_profile.py`

## Scope
No visible portfolio content, styling, or navigation is changed. This only reduces duplicate profile metadata and prevents stale professional links from being regenerated or enforced by CI.