### PR TITLE
Sync visible profile links from machine-readable CV

### DIFF
--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -90,6 +90,38 @@ def maintain_structured_profile(text: str, profile_urls: list[str]) -> str:
     return text
 
 
+def maintain_visible_profile_links(text: str, profile_urls: dict[str, str]) -> str:
+    block_pattern = re.compile(
+        r'(<div class="profile-links">)(.*?)(\n\s*</div>\n\s*</div>\n\s*</aside>)',
+        flags=re.DOTALL,
+    )
+    match = block_pattern.search(text)
+    if not match:
+        raise SystemExit("Could not find visible profile links block")
+
+    block = match.group(2)
+    labels = {
+        "GitHub": "GitHub",
+        "Qiita": "Qiita",
+        "LinkedIn": "LinkedIn",
+        "Google Scholar": "Google Scholar",
+    }
+    for field, label in labels.items():
+        anchor_pattern = re.compile(
+            rf'(<a\b[^>]*\bhref=")[^"]+("[^>]*>.*?{re.escape(label)}.*?</a>)',
+            flags=re.DOTALL,
+        )
+        block, count = anchor_pattern.subn(
+            lambda anchor_match: f'{anchor_match.group(1)}{profile_urls[field]}{anchor_match.group(2)}',
+            block,
+            count=1,
+        )
+        if count != 1:
+            raise SystemExit(f"Could not find visible {field} profile link")
+
+    return text[: match.start(2)] + block + text[match.end(2) :]
+
+
 def maintain_visible_profile(text: str) -> str:
     role = "Ph.D. Student · Special Assistant · Computer Vision Researcher"
     empty = '<span id="typing-text"></span>'
@@ -144,9 +176,10 @@ def maintain_canonical_url(text: str) -> str:
 def main() -> None:
     text = INDEX_PATH.read_text(encoding="utf-8")
     cv_text = CV_PATH.read_text(encoding="utf-8")
-    profile_urls = [read_cv_field(cv_text, label) for label in PROFILE_FIELDS]
+    profile_urls = {label: read_cv_field(cv_text, label) for label in PROFILE_FIELDS}
     text = maintain_page_titles(text)
-    text = maintain_structured_profile(text, profile_urls)
+    text = maintain_structured_profile(text, [profile_urls[label] for label in PROFILE_FIELDS])
+    text = maintain_visible_profile_links(text, profile_urls)
     text = maintain_visible_profile(text)
     text = maintain_canonical_url(text)
     INDEX_PATH.write_text(text, encoding="utf-8")

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -108,7 +108,7 @@ def maintain_visible_profile_links(text: str, profile_urls: dict[str, str]) -> s
     }
     for field, label in labels.items():
         anchor_pattern = re.compile(
-            rf'(<a\b[^>]*\bhref=")([^"]+)("[^>]*>.*?{re.escape(label)}.*?</a>)',
+            rf'(<a\b[^>]*\bhref=")([^"]+)("[^>]*>(?:(?!</a>).)*?{re.escape(label)}(?:(?!</a>).)*?</a>)',
             flags=re.DOTALL,
         )
 

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -108,14 +108,18 @@ def maintain_visible_profile_links(text: str, profile_urls: dict[str, str]) -> s
     }
     for field, label in labels.items():
         anchor_pattern = re.compile(
-            rf'(<a\b[^>]*\bhref=")[^"]+("[^>]*>.*?{re.escape(label)}.*?</a>)',
+            rf'(<a\b[^>]*\bhref=")([^"]+)("[^>]*>.*?{re.escape(label)}.*?</a>)',
             flags=re.DOTALL,
         )
-        block, count = anchor_pattern.subn(
-            lambda anchor_match: f'{anchor_match.group(1)}{profile_urls[field]}{anchor_match.group(2)}',
-            block,
-            count=1,
-        )
+
+        def sync_anchor(anchor_match: re.Match[str]) -> str:
+            current_url = anchor_match.group(2)
+            desired_url = profile_urls[field]
+            if current_url == desired_url or current_url.startswith(desired_url + "&"):
+                return anchor_match.group(0)
+            return f"{anchor_match.group(1)}{desired_url}{anchor_match.group(3)}"
+
+        block, count = anchor_pattern.subn(sync_anchor, block, count=1)
         if count != 1:
             raise SystemExit(f"Could not find visible {field} profile link")
 


### PR DESCRIPTION
## Why
Professional profile URLs are already sourced from `assets/cv.txt` for JSON-LD and consistency checks, but the visible sidebar links in `index.html` could still drift independently. That means a future GitHub, LinkedIn, Qiita, or Google Scholar URL change could leave the visitor-facing navigation stale while structured metadata is correct.

## What changed
- Read the four professional profile URLs from `assets/cv.txt` as a keyed source.
- Keep the visible sidebar GitHub, LinkedIn, Qiita, and Google Scholar links aligned during deterministic maintenance.
- Preserve harmless extra query parameters on an otherwise matching URL, such as Google Scholar's `&hl=ja` locale parameter.
- Fail maintenance if an expected visible professional profile link cannot be found, instead of silently skipping it.

## Impact
No visual redesign and no current visitor-facing URL change. This is a maintenance/reliability improvement that prevents future profile-link drift for researchers, recruiters, and other visitors.