### PR TITLE
Unify deterministic portfolio maintenance

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -56,10 +56,7 @@ jobs:
               raise SystemExit('Thumbnail cleanup still depends on current-run download success')
           PY
 
-      - name: Keep profile metadata aligned
-        run: python scripts/maintain_profile_metadata.py
-
-      - name: Keep site interactions and external links aligned
+      - name: Keep deterministic portfolio maintenance aligned
         run: python scripts/run_deterministic_maintenance.py
 
       - name: Commit and Push changes

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Use Python 3.14 and Node 24 for maintenance and validation so local runs match G
 python3.14 -m pip install -r requirements-maintenance.txt
 python3.14 -m py_compile scripts/*.py
 node --check main.js
-python3.14 scripts/maintain_profile_metadata.py
 python3.14 scripts/run_deterministic_maintenance.py
 python3.14 scripts/check_app_repo_links.py
 python3.14 scripts/check_local_deep_links.py

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -12,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 MAINTENANCE_SCRIPTS = (
+    "scripts/maintain_profile_metadata.py",
     "scripts/maintain_toc_fallback.py",
     "scripts/maintain_tabs.py",
     "scripts/maintain_stable_section_ids.py",


### PR DESCRIPTION
## Summary
- include `maintain_profile_metadata.py` in `run_deterministic_maintenance.py`
- remove the separate profile-maintenance step from the optimizer workflow
- simplify the README local validation sequence to use the unified runner

## Why
`maintain_profile_metadata.py` was the only deterministic profile transform invoked outside the central maintenance runner. That made local maintenance and CI depend on remembering a separate command, despite the runner being described as the deterministic portfolio maintenance entry point.

This keeps one command responsible for all deterministic transforms while preserving the existing dedicated validation step in the post-optimization workflow for clearer failure diagnostics.

## Scope
No visitor-facing content or styling changes. This only reduces maintenance drift and duplicate invocation paths.