### PR TITLE
Keep all public contact references aligned with the CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ python3.14 scripts/check_security_contact.py
 python3.14 scripts/check_structured_profile.py
 python3.14 scripts/check_llms_profile.py
 python3.14 scripts/check_year_filter_coverage.py
-git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md
+git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md llms.txt SECURITY.md .well-known/security.txt
 ```
 
 If the final command reports changes, include the generated maintenance updates in the same branch before pushing.

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -8,6 +8,10 @@ import re
 INDEX_PATH = Path("index.html")
 NOT_FOUND_PATH = Path("404.html")
 README_PATH = Path("README.md")
+LLMS_PATH = Path("llms.txt")
+SECURITY_POLICY_PATH = Path("SECURITY.md")
+SECURITY_CONTACT_PATH = Path(".well-known/security.txt")
+MAIN_JS_PATH = Path("main.js")
 CV_PATH = Path("assets/cv.txt")
 PROFILE_FIELDS = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")
 
@@ -179,6 +183,48 @@ def maintain_readme_contact(text: str, contact_email: str) -> str:
     return text
 
 
+def maintain_llms_contact(text: str, contact_email: str) -> str:
+    contact_pattern = re.compile(r"(?m)^- Contact: mailto:\S+\s*$")
+    text, count = contact_pattern.subn(
+        f"- Contact: mailto:{contact_email}", text, count=1
+    )
+    if count != 1:
+        raise SystemExit("Could not find llms.txt contact field")
+    return text
+
+
+def maintain_security_policy_contact(text: str, contact_email: str) -> str:
+    contact_pattern = re.compile(
+        r"(please report it privately by email to `)[^`]+(`\.)"
+    )
+    text, count = contact_pattern.subn(
+        rf"\g<1>{contact_email}\g<2>", text, count=1
+    )
+    if count != 1:
+        raise SystemExit("Could not find SECURITY.md private contact")
+    return text
+
+
+def maintain_security_contact(text: str, contact_email: str) -> str:
+    contact_pattern = re.compile(r"(?m)^Contact: mailto:\S+\s*$")
+    text, count = contact_pattern.subn(
+        f"Contact: mailto:{contact_email}", text, count=1
+    )
+    if count != 1:
+        raise SystemExit("Could not find security.txt contact field")
+    return text
+
+
+def maintain_form_fallback_contact(text: str, contact_email: str) -> str:
+    contact_pattern = re.compile(r"(link\.href = 'mailto:)[^']+(';)")
+    text, count = contact_pattern.subn(
+        rf"\g<1>{contact_email}\g<2>", text, count=1
+    )
+    if count != 1:
+        raise SystemExit("Could not find contact form email fallback")
+    return text
+
+
 def maintain_recovery_links(
     text: str, profile_urls: dict[str, str], contact_email: str
 ) -> str:
@@ -293,6 +339,10 @@ def main() -> None:
     text = INDEX_PATH.read_text(encoding="utf-8")
     not_found_text = NOT_FOUND_PATH.read_text(encoding="utf-8")
     readme_text = README_PATH.read_text(encoding="utf-8")
+    llms_text = LLMS_PATH.read_text(encoding="utf-8")
+    security_policy_text = SECURITY_POLICY_PATH.read_text(encoding="utf-8")
+    security_contact_text = SECURITY_CONTACT_PATH.read_text(encoding="utf-8")
+    main_js_text = MAIN_JS_PATH.read_text(encoding="utf-8")
     cv_text = CV_PATH.read_text(encoding="utf-8")
     profile_urls = {label: read_cv_field(cv_text, label) for label in PROFILE_FIELDS}
     contact_email = read_cv_field(cv_text, "Email")
@@ -305,9 +355,17 @@ def main() -> None:
     text = maintain_canonical_url(text)
     not_found_text = maintain_recovery_links(not_found_text, profile_urls, contact_email)
     readme_text = maintain_readme_contact(readme_text, contact_email)
+    llms_text = maintain_llms_contact(llms_text, contact_email)
+    security_policy_text = maintain_security_policy_contact(security_policy_text, contact_email)
+    security_contact_text = maintain_security_contact(security_contact_text, contact_email)
+    main_js_text = maintain_form_fallback_contact(main_js_text, contact_email)
     INDEX_PATH.write_text(text, encoding="utf-8")
     NOT_FOUND_PATH.write_text(not_found_text, encoding="utf-8")
     README_PATH.write_text(readme_text, encoding="utf-8")
+    LLMS_PATH.write_text(llms_text, encoding="utf-8")
+    SECURITY_POLICY_PATH.write_text(security_policy_text, encoding="utf-8")
+    SECURITY_CONTACT_PATH.write_text(security_contact_text, encoding="utf-8")
+    MAIN_JS_PATH.write_text(main_js_text, encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
`assets/cv.txt` is already the source of truth for the visible contact link, README contact, and 404 recovery link, but the same email address is still duplicated in `llms.txt`, `SECURITY.md`, `.well-known/security.txt`, and the contact-form fallback in `main.js`.

That duplication is harmless today because the values match, but a future email change can leave researcher/recruiter contact paths or the security reporting address stale.

## What changed
- Extend `maintain_profile_metadata.py` to sync the CV email into `llms.txt`.
- Sync the private vulnerability-reporting address in `SECURITY.md` and `.well-known/security.txt`.
- Sync the email fallback used when the contact form fails in `main.js`.
- Fail maintenance if any expected contact target disappears, instead of silently leaving stale data.
- Expand the README local `git diff --exit-code` check to cover every file this contact maintenance can change.

## Scope
No visual changes and no contact value change. This only reduces future drift and keeps useful navigation/recovery paths consistent.