### PR TITLE
Commit every generated contact metadata file

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -63,7 +63,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "chore: update portfolio assets and optimized images"
-          file_pattern: "assets/* index.html 404.html main.js style.css sitemap.xml README.md"
+          file_pattern: "assets/* index.html 404.html main.js style.css sitemap.xml README.md llms.txt SECURITY.md .well-known/security.txt"
           commit_user_name: "sakai1250"
           commit_user_email: "92532910+sakai1250@users.noreply.github.com"
           commit_author: "sakai1250 <92532910+sakai1250@users.noreply.github.com>"


### PR DESCRIPTION
## Why
`run_deterministic_maintenance.py` now updates contact information in `llms.txt`, `SECURITY.md`, and `.well-known/security.txt`, but the optimization workflow's auto-commit file list did not include those files.

That means a future email change in `assets/cv.txt` could be corrected inside the workflow and then silently left uncommitted, breaking the intended single-source-of-truth behavior.

## Change
Add the three generated contact files to the `git-auto-commit-action` `file_pattern`.

## Impact
- Researcher/recruiter: public contact routes stay aligned after CV email updates.
- Engineer: deterministic maintenance output is fully persisted instead of leaving generated changes behind.
- No visual or content change today; this fixes update reliability.