### PR TITLE
Keep machine-readable profile summary aligned with the CV

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Taigo Sakai
 
-> Ph.D. student, Special Assistant, Computer Vision and Deep Learning researcher, and engineer at Meijo University.
+> Ph.D. Student | Special Assistant | Computer Vision Researcher @ Meijo University
 
 Use the machine-readable CV as the primary source for biographical, publication, award, education, experience, and skill information.
 

--- a/scripts/check_llms_profile.py
+++ b/scripts/check_llms_profile.py
@@ -65,12 +65,13 @@ def main():
     readme_text = readme_path.read_text(encoding="utf-8")
 
     cv_roles, cv_affiliation = read_cv_header_profile(cv_text)
-    expected_current_role = (
-        f"- Current role: {' | '.join(cv_roles)} @ {cv_affiliation}"
-    )
+    role_text = " | ".join(cv_roles)
+    expected_summary_role = f"> {role_text} @ {cv_affiliation}"
+    expected_current_role = f"- Current role: {role_text} @ {cv_affiliation}"
 
     required_identity = [
         "# Taigo Sakai",
+        expected_summary_role,
         "English name: Taigo Sakai",
         "Japanese name: 坂井 泰吾",
         "Publication name: T. Sakai",


### PR DESCRIPTION
## Why
`llms.txt` already derives its `Current role` expectation from `assets/cv.txt`, but the introductory summary line still used separately maintained role wording. That leaves two different machine-readable descriptions of the current role and affiliation.

## Changes
- Align the `llms.txt` summary line with the CV header role and affiliation.
- Extend `check_llms_profile.py` so the summary line and `Current role` must both match the CV header.

## Impact
This reduces stale or conflicting role information for research collaborators, recruiters, search systems, and AI consumers without changing the visible portfolio design.