### PR TITLE
Enforce CV-aligned Person metadata

### DIFF
--- a/scripts/check_llms_profile.py
+++ b/scripts/check_llms_profile.py
@@ -131,10 +131,12 @@ def main():
         if person.get(field) != expected:
             raise SystemExit(f"index.html Person JSON-LD has unexpected {field}: {person.get(field)!r}")
 
-    job_title = str(person.get("jobTitle", ""))
-    for role in ("Ph.D. Student", "Special Assistant", "Researcher", "Engineer"):
-        if role.casefold() not in job_title.casefold():
-            raise SystemExit(f"index.html Person JSON-LD jobTitle is missing role: {role}")
+    expected_job_title = " / ".join(cv_roles)
+    if person.get("jobTitle") != expected_job_title:
+        raise SystemExit(
+            "index.html Person JSON-LD jobTitle must match assets/cv.txt: "
+            f"expected={expected_job_title!r}, actual={person.get('jobTitle')!r}"
+        )
 
     same_as = person.get("sameAs")
     if not isinstance(same_as, list):
@@ -144,8 +146,8 @@ def main():
             raise SystemExit(f"index.html Person JSON-LD sameAs is missing profile: {profile}")
 
     affiliation = person.get("affiliation")
-    if not isinstance(affiliation, dict) or affiliation.get("name") != "Meijo University":
-        raise SystemExit("index.html Person JSON-LD affiliation must identify Meijo University")
+    if not isinstance(affiliation, dict) or affiliation.get("name") != cv_affiliation:
+        raise SystemExit("index.html Person JSON-LD affiliation must match assets/cv.txt")
 
     print("OK: portfolio, recovery navigation, CV, structured metadata, and machine-readable sources expose a consistent professional profile")
 

--- a/scripts/check_structured_profile.py
+++ b/scripts/check_structured_profile.py
@@ -70,10 +70,23 @@ def read_cv_field(cv_text, label):
     return match.group(1)
 
 
+def read_cv_header_profile(cv_text):
+    lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
+    if len(lines) < 5 or " | " not in lines[3]:
+        raise SystemExit("assets/cv.txt is missing the expected role and affiliation header")
+
+    roles = [role.strip() for role in lines[3].split("|") if role.strip()]
+    affiliation = lines[4].split(",", 1)[0].strip()
+    if not roles or not affiliation:
+        raise SystemExit("assets/cv.txt has an incomplete role or affiliation header")
+    return roles, affiliation
+
+
 def main():
     parser = JsonLdParser()
     parser.feed(Path("index.html").read_text(encoding="utf-8"))
     cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
+    cv_roles, cv_affiliation = read_cv_header_profile(cv_text)
 
     people = []
     for raw in parser.blocks:
@@ -99,13 +112,12 @@ def main():
         if not str(person.get(key, "")).strip():
             raise SystemExit(f"Person JSON-LD is missing {key}")
 
-    job_title = str(person["jobTitle"])
-    required_roles = ("Ph.D. Student", "Special Assistant")
-    for required_role in required_roles:
-        if required_role not in job_title:
-            raise SystemExit(
-                f"Person JSON-LD jobTitle is missing current role: {required_role}"
-            )
+    expected_job_title = " / ".join(cv_roles)
+    if person["jobTitle"] != expected_job_title:
+        raise SystemExit(
+            "Person JSON-LD jobTitle must match the assets/cv.txt role header: "
+            f"expected={expected_job_title!r}, actual={person['jobTitle']!r}"
+        )
 
     if person["url"] != "https://sakai1250.github.io/":
         raise SystemExit(f'unexpected profile URL: {person["url"]}')
@@ -175,10 +187,7 @@ def main():
     same_as = person.get("sameAs")
     if not isinstance(same_as, list):
         raise SystemExit("Person JSON-LD sameAs must be a list")
-    required_profiles = {
-        read_cv_field(cv_text, label)
-        for label in PROFILE_FIELDS
-    }
+    required_profiles = {read_cv_field(cv_text, label) for label in PROFILE_FIELDS}
     missing_profiles = sorted(required_profiles - set(same_as))
     if missing_profiles:
         raise SystemExit(
@@ -186,9 +195,9 @@ def main():
         )
 
     affiliation = person.get("affiliation")
-    if not isinstance(affiliation, dict) or affiliation.get("name") != "Meijo University":
+    if not isinstance(affiliation, dict) or affiliation.get("name") != cv_affiliation:
         raise SystemExit(
-            "Person JSON-LD must identify Meijo University as the current affiliation"
+            "Person JSON-LD affiliation must match the current assets/cv.txt affiliation"
         )
     if affiliation.get("@type") != "CollegeOrUniversity":
         raise SystemExit("Person JSON-LD affiliation must use CollegeOrUniversity")
@@ -200,7 +209,7 @@ def main():
 
     if person["name"].upper() not in cv_text.upper():
         raise SystemExit("assets/cv.txt is missing the JSON-LD person name")
-    for required_role in required_roles:
+    for required_role in cv_roles:
         if required_role not in cv_text:
             raise SystemExit(f"assets/cv.txt is missing current role: {required_role}")
     if affiliation["name"] not in cv_text:


### PR DESCRIPTION
Closes #267

## What changed
- require `Person.jobTitle` to exactly match the role header in `assets/cv.txt`
- require the structured affiliation to match the CV header instead of a duplicated fixed string
- apply the same rule in both structured-profile and machine-readable-profile checks

## Why
The generated JSON-LD now uses `Ph.D. Student / Special Assistant / Computer Vision Researcher`. Exact CV-derived checks make future role changes fail CI if `index.html` or its maintenance logic drifts.

## Validation
- `index.html` is already refreshed by deterministic maintenance on main
- the affected files are covered by the Structured profile and Site integrity workflows
- no visible layout or decorative changes