### PR TITLE
Track portfolio data in homepage freshness

### DIFF
--- a/.github/workflows/static-fallbacks.yml
+++ b/.github/workflows/static-fallbacks.yml
@@ -6,6 +6,7 @@ on:
       - 'index.html'
       - 'main.js'
       - 'style.css'
+      - 'assets/data.json'
       - 'sitemap.xml'
       - 'scripts/maintain_*.py'
       - 'scripts/run_deterministic_maintenance.py'

--- a/scripts/maintain_static_fallbacks.py
+++ b/scripts/maintain_static_fallbacks.py
@@ -18,6 +18,7 @@ TRACKED_PAGE_FILES = (
     "index.html",
     "main.js",
     "style.css",
+    "assets/data.json",
     "scripts/maintain_*.py",
     "scripts/run_deterministic_maintenance.py",
 )


### PR DESCRIPTION
## Problem
`assets/data.json` drives visitor-facing Engineering content, but `maintain_static_fallbacks.py` did not include it when calculating the homepage `last updated` date. A data-only update could therefore leave the footer and homepage sitemap freshness stale.

The static-fallback PR check also did not run when only `assets/data.json` changed.

## Change
- Include `assets/data.json` in `TRACKED_PAGE_FILES` for homepage freshness.
- Trigger the static-fallback validation workflow for `assets/data.json` changes.

## Why this matters
- Researcher: the public portfolio freshness signal reflects all visitor-facing content, not only Research HTML and maintenance code.
- Recruiter: Engineering/project information no longer changes behind an old footer date.
- Engineer: the freshness calculation and workflow trigger now cover the same visitor-facing data source already used by the site.

## Validation
The existing static-fallback workflow runs `maintain_static_fallbacks.py` and fails if `index.html` or `sitemap.xml` would change unexpectedly.