### PR TITLE
Derive public profile titles from CV roles

### DIFF
--- a/scripts/maintain_header_controls.py
+++ b/scripts/maintain_header_controls.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import html
+import re
 
 import maintain_filter_accessibility
 from maintain_asset_versions import main as maintain_asset_versions
@@ -6,37 +8,31 @@ from maintain_asset_versions import main as maintain_asset_versions
 
 path = Path('index.html')
 text = path.read_text(encoding='utf-8')
+cv_text = Path('assets/cv.txt').read_text(encoding='utf-8')
 
-# Make search results and shared links identify both the current academic stage
-# and the research field immediately. Keep older titles as migration inputs so
-# repeated maintenance remains safe across previously generated states.
-legacy_titles = (
-    '<title>Taigo Sakai | Portfolio</title>',
-    '<title>Taigo Sakai | Computer Vision Researcher</title>',
-    '<title>Taigo Sakai | Ph.D. Student &amp; Computer Vision Researcher</title>',
-)
-current_title = '<title>Taigo Sakai | Ph.D. Student, Special Assistant &amp; Computer Vision Researcher</title>'
-for legacy_title in legacy_titles:
-    if legacy_title in text:
-        text = text.replace(legacy_title, current_title, 1)
-        break
-else:
-    if current_title not in text:
-        raise SystemExit('Could not find expected document title')
+# Derive public titles from the CV role header so search results and shared links
+# cannot drift when the current academic or research role changes.
+cv_lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
+if len(cv_lines) < 5 or ' | ' not in cv_lines[3]:
+    raise SystemExit('assets/cv.txt is missing the expected role header')
+roles = [role.strip() for role in cv_lines[3].split('|') if role.strip()]
+if not roles:
+    raise SystemExit('assets/cv.txt has an empty role header')
+role_title = roles[0] if len(roles) == 1 else ', '.join(roles[:-1]) + ' & ' + roles[-1]
+page_title = html.escape(f'Taigo Sakai | {role_title}', quote=True)
 
-legacy_og_titles = (
-    '<meta property="og:title" content="Taigo Sakai | Portfolio">',
-    '<meta property="og:title" content="Taigo Sakai | Computer Vision Researcher">',
-    '<meta property="og:title" content="Taigo Sakai | Ph.D. Student &amp; Computer Vision Researcher">',
+def replace_title(pattern, replacement, label):
+    global text
+    text, count = re.subn(pattern, replacement, text, count=1)
+    if count != 1:
+        raise SystemExit(f'Could not find expected {label}')
+
+replace_title(r'<title>Taigo Sakai \| [^<]+</title>', f'<title>{page_title}</title>', 'document title')
+replace_title(
+    r'<meta property="og:title" content="Taigo Sakai \| [^"]+">',
+    f'<meta property="og:title" content="{page_title}">',
+    'Open Graph title',
 )
-current_og_title = '<meta property="og:title" content="Taigo Sakai | Ph.D. Student, Special Assistant &amp; Computer Vision Researcher">'
-for legacy_og_title in legacy_og_titles:
-    if legacy_og_title in text:
-        text = text.replace(legacy_og_title, current_og_title, 1)
-        break
-else:
-    if current_og_title not in text:
-        raise SystemExit('Could not find expected Open Graph title')
 
 # Keep social-card metadata as complete as the Open Graph metadata. This makes
 # shared portfolio links identify the person and research field without relying
@@ -44,28 +40,21 @@ else:
 twitter_creator = '<meta name="twitter:creator" content="@ikaitaig">'
 twitter_metadata = (
     '<meta name="twitter:creator" content="@ikaitaig">\n'
-    '  <meta name="twitter:title" content="Taigo Sakai | Ph.D. Student, Special Assistant &amp; Computer Vision Researcher">\n'
+    f'  <meta name="twitter:title" content="{page_title}">\n'
     '  <meta name="twitter:description" content="Ph.D. Student and Special Assistant at Meijo University researching Computer Vision, Continual Learning, and Multi-View Tracking.">\n'
     '  <meta name="twitter:image" content="https://github.com/sakai1250.png">\n'
     '  <meta name="twitter:image:alt" content="Portrait of Taigo Sakai">'
 )
-legacy_twitter_titles = (
-    '<meta name="twitter:title" content="Taigo Sakai | Computer Vision Researcher">',
-    '<meta name="twitter:title" content="Taigo Sakai | Ph.D. Student &amp; Computer Vision Researcher">',
-)
-current_twitter_title = '<meta name="twitter:title" content="Taigo Sakai | Ph.D. Student, Special Assistant &amp; Computer Vision Researcher">'
 if '<meta name="twitter:title"' not in text:
     if twitter_creator not in text:
         raise SystemExit('Could not find Twitter creator metadata')
     text = text.replace(twitter_creator, twitter_metadata, 1)
 else:
-    for legacy_twitter_title in legacy_twitter_titles:
-        if legacy_twitter_title in text:
-            text = text.replace(legacy_twitter_title, current_twitter_title, 1)
-            break
-    else:
-        if current_twitter_title not in text:
-            raise SystemExit('Could not find expected Twitter title')
+    replace_title(
+        r'<meta name="twitter:title" content="Taigo Sakai \| [^"]+">',
+        f'<meta name="twitter:title" content="{page_title}">',
+        'Twitter title',
+    )
 
 og_image = '<meta property="og:image" content="https://github.com/sakai1250.png">'
 og_image_with_alt = (

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -2,6 +2,7 @@
 """Keep portfolio profile metadata and visible role fallbacks aligned."""
 
 from pathlib import Path
+import html
 import re
 
 
@@ -42,27 +43,23 @@ def read_cv_education_label(cv_text: str, prefix: str) -> str:
     return match.group(1)
 
 
-def maintain_page_titles(text: str) -> str:
-    old_title = "Taigo Sakai | Ph.D. Student &amp; Computer Vision Researcher"
-    new_title = "Taigo Sakai | Ph.D. Student, Special Assistant &amp; Computer Vision Researcher"
+def build_page_title(cv_text: str) -> str:
+    roles, _ = read_cv_header_profile(cv_text)
+    role_title = roles[0] if len(roles) == 1 else ", ".join(roles[:-1]) + " & " + roles[-1]
+    return f"Taigo Sakai | {role_title}"
 
-    title_fields = (
-        f"<title>{old_title}</title>",
-        f'<meta property="og:title" content="{old_title}">',
-        f'<meta name="twitter:title" content="{old_title}">',
+
+def maintain_page_titles(text: str, cv_text: str) -> str:
+    desired_title = html.escape(build_page_title(cv_text), quote=True)
+    patterns = (
+        (re.compile(r"<title>Taigo Sakai \| [^<]+</title>"), f"<title>{desired_title}</title>", "document title"),
+        (re.compile(r'<meta property="og:title" content="Taigo Sakai \| [^"]+">'), f'<meta property="og:title" content="{desired_title}">', "Open Graph title"),
+        (re.compile(r'<meta name="twitter:title" content="Taigo Sakai \| [^"]+">'), f'<meta name="twitter:title" content="{desired_title}">', "Twitter title"),
     )
-    updated_fields = (
-        f"<title>{new_title}</title>",
-        f'<meta property="og:title" content="{new_title}">',
-        f'<meta name="twitter:title" content="{new_title}">',
-    )
-
-    for old, new in zip(title_fields, updated_fields):
-        if old in text:
-            text = text.replace(old, new, 1)
-        elif new not in text:
-            raise SystemExit(f"Could not find expected profile title field: {old}")
-
+    for pattern, replacement, label in patterns:
+        text, count = pattern.subn(replacement, text, count=1)
+        if count != 1:
+            raise SystemExit(f"Could not find expected {label}")
     return text
 
 
@@ -363,7 +360,7 @@ def main() -> None:
     cv_text = CV_PATH.read_text(encoding="utf-8")
     profile_urls = {label: read_cv_field(cv_text, label) for label in PROFILE_FIELDS}
     contact_email = read_cv_field(cv_text, "Email")
-    text = maintain_page_titles(text)
+    text = maintain_page_titles(text, cv_text)
     text = maintain_structured_profile(
         text, [profile_urls[label] for label in PROFILE_FIELDS], cv_text
     )


### PR DESCRIPTION
## Summary
- derive the document, Open Graph, and Twitter titles from the role header in `assets/cv.txt`
- remove the duplicated current-role title literal from both title maintenance paths
- preserve deterministic replacement for previously generated `Taigo Sakai | ...` titles

## Why
A CV role change should update public search/social identity from the same source of truth instead of requiring edits in multiple scripts.

## Validation
- `scripts/check_structured_profile.py` remains the independent assertion that all three public titles match the CV roles
- deterministic maintenance should be idempotent because each run rewrites the same three fields to the same CV-derived value

Closes #271