### PR TITLE
Preserve section separators during profile maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Personal portfolio for Taigo Sakai, a Ph.D. student, Special Assistant, and comp
 - **Qiita:** https://qiita.com/sakai1250
 - **LinkedIn:** https://www.linkedin.com/in/sakai1250
 - **Contact:** [263441505@ccmailg.meijo-u.ac.jp](mailto:263441505@ccmailg.meijo-u.ac.jp)
+
 ## Focus
 
 - Research: continual learning, long-tailed learning, multi-view detection and tracking

--- a/llms.txt
+++ b/llms.txt
@@ -29,6 +29,7 @@ Use the machine-readable CV as the primary source for biographical, publication,
 - LinkedIn: https://www.linkedin.com/in/sakai1250
 - Qiita: https://qiita.com/sakai1250
 - Contact: mailto:263441505@ccmailg.meijo-u.ac.jp
+
 ## Research focus
 
 - Computer Vision

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -188,7 +188,7 @@ def maintain_visible_contact(text: str, contact_email: str) -> str:
 
 def maintain_readme_contact(text: str, contact_email: str) -> str:
     contact_pattern = re.compile(
-        r"(?m)^- \*\*Contact:\*\* (?:mailto:\S+|\[[^\]]+\]\(mailto:[^)]+\))\s*$"
+        r"(?m)^- \*\*Contact:\*\* (?:mailto:\S+|\[[^\]]+\]\(mailto:[^)]+\))[ \t]*$"
     )
     desired = f"- **Contact:** [{contact_email}](mailto:{contact_email})"
     text, count = contact_pattern.subn(desired, text, count=1)
@@ -198,7 +198,7 @@ def maintain_readme_contact(text: str, contact_email: str) -> str:
 
 
 def maintain_llms_contact(text: str, contact_email: str) -> str:
-    contact_pattern = re.compile(r"(?m)^- Contact: mailto:\S+\s*$")
+    contact_pattern = re.compile(r"(?m)^- Contact: mailto:\S+[ \t]*$")
     text, count = contact_pattern.subn(
         f"- Contact: mailto:{contact_email}", text, count=1
     )
@@ -220,7 +220,7 @@ def maintain_security_policy_contact(text: str, contact_email: str) -> str:
 
 
 def maintain_security_contact(text: str, contact_email: str) -> str:
-    contact_pattern = re.compile(r"(?m)^Contact: mailto:\S+\s*$")
+    contact_pattern = re.compile(r"(?m)^Contact: mailto:\S+[ \t]*$")
     text, count = contact_pattern.subn(
         f"Contact: mailto:{contact_email}", text, count=1
     )

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://sakai1250.github.io/llms.txt</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
## Summary

- restrict contact-line regex trailing whitespace to spaces and tabs so it cannot consume following newlines
- restore the blank-line separator after Contact in `README.md`
- restore the blank-line separator after Contact in `llms.txt`

## Why

The deterministic profile maintenance currently uses `\s*$` on contact lines. Because `\s` includes newlines, refreshing contact metadata can collapse the following section boundary. This already caused `Quick links` / `Focus` and `Primary sources` / `Research focus` to run together.

The change keeps contact synchronization intact while preserving unrelated surrounding whitespace.

Closes #275