### PR TITLE
Derive visible profile role from CV

### DIFF
--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -266,13 +266,16 @@ def maintain_recovery_links(
     return text
 
 
-def maintain_visible_profile(text: str) -> str:
-    role = "Ph.D. Student · Special Assistant · Computer Vision Researcher"
-    empty = '<span id="typing-text"></span>'
-    filled = f'<span id="typing-text">{role}</span>'
-    if empty in text:
-        text = text.replace(empty, filled, 1)
-    elif filled not in text:
+def maintain_visible_profile(text: str, cv_text: str) -> str:
+    roles, _ = read_cv_header_profile(cv_text)
+    role = " · ".join(roles)
+    role_pattern = re.compile(r'(<span id="typing-text">)[^<]*(</span>)')
+    text, role_count = role_pattern.subn(
+        lambda match: f"{match.group(1)}{html.escape(role)}{match.group(2)}",
+        text,
+        count=1,
+    )
+    if role_count != 1:
         raise SystemExit("Could not find expected visible profile role")
 
     old_ja_department = "理工学研究科 電気電子・情報・材料工学専攻"
@@ -366,7 +369,7 @@ def main() -> None:
     )
     text = maintain_visible_profile_links(text, profile_urls)
     text = maintain_visible_contact(text, contact_email)
-    text = maintain_visible_profile(text)
+    text = maintain_visible_profile(text, cv_text)
     text = maintain_visible_education(text, cv_text)
     text = maintain_canonical_url(text)
     not_found_text = maintain_recovery_links(not_found_text, profile_urls, contact_email)


### PR DESCRIPTION
## Summary
- derive the visible `#typing-text` role line from the role header in `assets/cv.txt`
- reuse the existing CV header parser and keep the current ` · ` presentation
- allow deterministic maintenance to replace a stale visible role instead of requiring the old hard-coded value

## Why
The document/social titles and JSON-LD already use the CV role header as their source of truth. This closes the remaining gap for the most prominent visitor-facing role line, reducing the chance that researchers or recruiters see conflicting current roles.

## Validation
- current visible output remains `Ph.D. Student · Special Assistant · Computer Vision Researcher`
- deterministic maintenance remains responsible for normalizing the field
- relevant GitHub Actions checks should verify idempotence and generated output

Closes #277