### PR TITLE
Derive sidebar roles from the CV header

### DIFF
--- a/.github/workflows/structured-profile.yml
+++ b/.github/workflows/structured-profile.yml
@@ -13,6 +13,7 @@ on:
       - 'scripts/maintain_profile_metadata.py'
       - 'scripts/maintain_header_controls.py'
       - 'scripts/check_structured_profile.py'
+      - 'scripts/check_sidebar_role_derivation.py'
       - 'scripts/check_llms_profile.py'
       - '.github/workflows/structured-profile.yml'
   pull_request:
@@ -26,6 +27,7 @@ on:
       - 'scripts/maintain_profile_metadata.py'
       - 'scripts/maintain_header_controls.py'
       - 'scripts/check_structured_profile.py'
+      - 'scripts/check_sidebar_role_derivation.py'
       - 'scripts/check_llms_profile.py'
       - '.github/workflows/structured-profile.yml'
 
@@ -45,5 +47,7 @@ jobs:
           python-version: '3.14'
       - name: Validate JSON-LD person metadata
         run: python scripts/check_structured_profile.py
+      - name: Validate CV-derived sidebar roles
+        run: python scripts/check_sidebar_role_derivation.py
       - name: Validate machine-readable profile routes
         run: python scripts/check_llms_profile.py

--- a/scripts/check_sidebar_role_derivation.py
+++ b/scripts/check_sidebar_role_derivation.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Verify that sidebar roles follow the CV header instead of fixed role text."""
+
+from pathlib import Path
+
+from maintain_profile_metadata import build_sidebar_roles
+
+
+def main() -> None:
+    synthetic_cv = """TAIGO SAKAI
+Portfolio: https://example.com
+Email: test@example.com
+Ph.D. Student | Visiting Researcher | Computer Vision Researcher
+Meijo University, Japan
+"""
+    japanese, english = build_sidebar_roles(synthetic_cv)
+    if english != "Ph.D. Student · Visiting Researcher":
+        raise SystemExit(f"English sidebar role did not follow changed CV roles: {english!r}")
+    if japanese != "博士後期課程 · Visiting Researcher":
+        raise SystemExit(f"Japanese sidebar role did not localize changed CV roles: {japanese!r}")
+
+    cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
+    index_text = Path("index.html").read_text(encoding="utf-8")
+    japanese, english = build_sidebar_roles(cv_text)
+    if japanese not in index_text:
+        raise SystemExit(f"Current Japanese sidebar role is not CV-derived: {japanese!r}")
+    if english not in index_text:
+        raise SystemExit(f"Current English sidebar role is not CV-derived: {english!r}")
+
+    print("OK: sidebar roles derive from the CV role header and follow role changes")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -36,6 +36,20 @@ def read_cv_header_profile(cv_text: str) -> tuple[list[str], str]:
     return roles, affiliation
 
 
+def build_sidebar_roles(cv_text: str) -> tuple[str, str]:
+    roles, _ = read_cv_header_profile(cv_text)
+    sidebar_roles = roles[:2]
+    if not sidebar_roles:
+        raise SystemExit("assets/cv.txt is missing roles for the profile sidebar")
+
+    localized_roles = {
+        "Ph.D. Student": "博士後期課程",
+    }
+    japanese = " · ".join(localized_roles.get(role, role) for role in sidebar_roles)
+    english = " · ".join(sidebar_roles)
+    return japanese, english
+
+
 def read_cv_education_label(cv_text: str, prefix: str) -> str:
     match = re.search(rf"^({re.escape(prefix)}[^\n]*)$", cv_text, flags=re.MULTILINE)
     if not match:
@@ -292,20 +306,28 @@ def maintain_visible_profile(text: str, cv_text: str) -> str:
     if current_en_department not in text:
         raise SystemExit("Could not find current English doctoral program wording")
 
+    japanese_sidebar_role, english_sidebar_role = build_sidebar_roles(cv_text)
     ja_pattern = re.compile(
-        r"(理工学研究科 電気・情報・材料・物質工学専攻<br>\n\s*博士後期課程)(?: · Special Assistant)+"
+        r"(理工学研究科 電気・情報・材料・物質工学専攻<br>\n\s*)[^\n<]+"
     )
-    text, ja_count = ja_pattern.subn(r"\1 · Special Assistant", text, count=1)
+    text, ja_count = ja_pattern.subn(
+        lambda match: f"{match.group(1)}{html.escape(japanese_sidebar_role)}",
+        text,
+        count=1,
+    )
     if ja_count != 1:
-        raise SystemExit("Could not normalize Japanese sidebar role")
+        raise SystemExit("Could not synchronize Japanese sidebar role")
 
     en_pattern = re.compile(
-        r"(Department of Electrical, Information, and Materials Science Engineering<br>\n\s*)"
-        r"Ph\.D\. (?:Course|Student)(?: · Special Assistant)+"
+        r"(Department of Electrical, Information, and Materials Science Engineering<br>\n\s*)[^\n<]+"
     )
-    text, en_count = en_pattern.subn(r"\1Ph.D. Student · Special Assistant", text, count=1)
+    text, en_count = en_pattern.subn(
+        lambda match: f"{match.group(1)}{html.escape(english_sidebar_role)}",
+        text,
+        count=1,
+    )
     if en_count != 1:
-        raise SystemExit("Could not normalize English sidebar role")
+        raise SystemExit("Could not synchronize English sidebar role")
 
     return text
 


### PR DESCRIPTION
Closes #279

## Summary
- derive the compact sidebar role labels from the role list in `assets/cv.txt`
- keep the current rendered Japanese and English wording unchanged
- localize `Ph.D. Student` to `博士後期課程` only for the Japanese sidebar
- add a regression check that changes the CV role header and verifies the sidebar derivation follows it
- run the new check in the Structured profile workflow

## Why
The main role line, page/social titles, and JSON-LD already use the CV as their source of truth. The sidebar was the remaining visible role string that deterministic maintenance could restore from hard-coded text.

## Validation
The new checker covers both the current rendered values and a synthetic role change so future CV role edits cannot silently leave the sidebar stale.