### PR TITLE
Derive social profile description from CV

### DIFF
--- a/.github/workflows/structured-profile.yml
+++ b/.github/workflows/structured-profile.yml
@@ -12,8 +12,10 @@ on:
       - 'assets/cv.txt'
       - 'scripts/maintain_profile_metadata.py'
       - 'scripts/maintain_header_controls.py'
+      - 'scripts/maintain_social_profile.py'
       - 'scripts/check_structured_profile.py'
       - 'scripts/check_sidebar_role_derivation.py'
+      - 'scripts/check_social_profile_derivation.py'
       - 'scripts/check_llms_profile.py'
       - '.github/workflows/structured-profile.yml'
   pull_request:
@@ -26,8 +28,10 @@ on:
       - 'assets/cv.txt'
       - 'scripts/maintain_profile_metadata.py'
       - 'scripts/maintain_header_controls.py'
+      - 'scripts/maintain_social_profile.py'
       - 'scripts/check_structured_profile.py'
       - 'scripts/check_sidebar_role_derivation.py'
+      - 'scripts/check_social_profile_derivation.py'
       - 'scripts/check_llms_profile.py'
       - '.github/workflows/structured-profile.yml'
 
@@ -49,5 +53,7 @@ jobs:
         run: python scripts/check_structured_profile.py
       - name: Validate CV-derived sidebar roles
         run: python scripts/check_sidebar_role_derivation.py
+      - name: Validate CV-derived social profile
+        run: python scripts/check_social_profile_derivation.py
       - name: Validate machine-readable profile routes
         run: python scripts/check_llms_profile.py

--- a/scripts/check_social_profile_derivation.py
+++ b/scripts/check_social_profile_derivation.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Verify that social profile text follows CV role and affiliation changes."""
+
+from html import escape
+from pathlib import Path
+
+from maintain_social_profile import build_social_description
+
+
+def main() -> None:
+    synthetic_cv = """TAIGO SAKAI
+Japanese name: 坂井 泰吾
+Publication name: T. Sakai
+Ph.D. Student | Visiting Researcher | Computer Vision Researcher
+Future University, Tokyo, Japan
+"""
+    synthetic_description = build_social_description(synthetic_cv)
+    expected_synthetic = (
+        "Ph.D. Student and Visiting Researcher at Future University researching "
+        "Computer Vision, Continual Learning, and Multi-View Tracking."
+    )
+    if synthetic_description != expected_synthetic:
+        raise SystemExit(
+            "Social description did not follow changed CV role/affiliation: "
+            f"expected={expected_synthetic!r}, actual={synthetic_description!r}"
+        )
+    if "Special Assistant" in synthetic_description or "Meijo University" in synthetic_description:
+        raise SystemExit("Social description retained stale current-profile text")
+
+    cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
+    index_text = Path("index.html").read_text(encoding="utf-8")
+    current_description = escape(build_social_description(cv_text), quote=True)
+    expected_tag = f'<meta name="twitter:description" content="{current_description}">'
+    if expected_tag not in index_text:
+        raise SystemExit("Current Twitter description does not match assets/cv.txt")
+
+    print("OK: social profile description derives from CV roles and affiliation")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_structured_profile.py
+++ b/scripts/check_structured_profile.py
@@ -6,6 +6,7 @@ import re
 
 
 PROFILE_FIELDS = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")
+RESEARCH_FOCUS = "Computer Vision, Continual Learning, and Multi-View Tracking"
 
 
 class JsonLdParser(HTMLParser):
@@ -162,19 +163,15 @@ def main():
             "meta and Open Graph descriptions must match: "
             f"description={description!r}, og:description={og_description!r}"
         )
-    required_twitter_terms = (
-        "Ph.D. Student",
-        "Special Assistant",
-        "Meijo University",
-        "Computer Vision",
+
+    social_roles = cv_roles[:2]
+    expected_twitter_description = (
+        f"{' and '.join(social_roles)} at {cv_affiliation} researching {RESEARCH_FOCUS}."
     )
-    missing_twitter_terms = [
-        term for term in required_twitter_terms if term not in twitter_description
-    ]
-    if missing_twitter_terms:
+    if twitter_description != expected_twitter_description:
         raise SystemExit(
-            "Twitter description is missing current professional context: "
-            + ", ".join(missing_twitter_terms)
+            "Twitter description must match the current CV roles and affiliation: "
+            f"expected={expected_twitter_description!r}, actual={twitter_description!r}"
         )
 
     og_image = single_value(parser.meta.get("og:image", []), "og:image")

--- a/scripts/maintain_social_profile.py
+++ b/scripts/maintain_social_profile.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Synchronize social-profile description metadata with the CV role header."""
+
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+
+RESEARCH_FOCUS = "Computer Vision, Continual Learning, and Multi-View Tracking"
+
+
+def read_cv_social_profile(cv_text: str) -> tuple[list[str], str]:
+    lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
+    if len(lines) < 5 or " | " not in lines[3]:
+        raise SystemExit("assets/cv.txt is missing the expected role and affiliation header")
+
+    roles = [role.strip() for role in lines[3].split("|") if role.strip()]
+    affiliation = lines[4].split(",", 1)[0].strip()
+    if not roles or not affiliation:
+        raise SystemExit("assets/cv.txt has an incomplete role or affiliation header")
+    return roles, affiliation
+
+
+def build_social_description(cv_text: str) -> str:
+    roles, affiliation = read_cv_social_profile(cv_text)
+    visible_roles = roles[:2]
+    role_phrase = " and ".join(visible_roles)
+    return f"{role_phrase} at {affiliation} researching {RESEARCH_FOCUS}."
+
+
+def main() -> None:
+    path = Path("index.html")
+    text = path.read_text(encoding="utf-8")
+    cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
+    description = html.escape(build_social_description(cv_text), quote=True)
+
+    pattern = re.compile(r'<meta name="twitter:description" content="[^"]*">')
+    replacement = f'<meta name="twitter:description" content="{description}">'
+    text, count = pattern.subn(replacement, text, count=1)
+    if count != 1:
+        raise SystemExit("Could not find exactly one Twitter description metadata tag")
+
+    path.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -19,6 +19,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_contact_form.py",
     "scripts/prepare_header_section_reordering.py",
     "scripts/maintain_header_controls.py",
+    "scripts/maintain_social_profile.py",
     "scripts/maintain_app_thumbnail_dimensions.py",
     "scripts/maintain_tab_deep_links.py",
     "scripts/maintain_header_stat_links.py",


### PR DESCRIPTION
Closes #281.

## What changed
- derive the Twitter social description from the first two current roles and current affiliation in `assets/cv.txt`
- keep the existing research-focus wording and current rendered description unchanged
- run the social-description transform as part of deterministic maintenance
- update structured-profile validation to compare against CV-derived role/affiliation values instead of fixed current titles
- add a synthetic role/affiliation regression check so stale social metadata is caught when the CV changes

## Why
The rest of the public professional identity already follows `assets/cv.txt`. Without this change, a future role or affiliation update could leave shared portfolio previews stale even while visible and structured profile data updates correctly.