### PR TITLE
Keep header social metadata aligned with CV

### DIFF
--- a/scripts/check_social_profile_derivation.py
+++ b/scripts/check_social_profile_derivation.py
@@ -34,6 +34,18 @@ Future University, Tokyo, Japan
     if expected_tag not in index_text:
         raise SystemExit("Current Twitter description does not match assets/cv.txt")
 
+    header_source = Path("scripts/maintain_header_controls.py").read_text(encoding="utf-8")
+    if "from maintain_social_profile import build_social_description" not in header_source:
+        raise SystemExit("Header maintenance does not reuse the CV-derived social description helper")
+    if "build_social_description(cv_text)" not in header_source:
+        raise SystemExit("Header maintenance does not derive social description from the current CV")
+    stale_literal = (
+        "Ph.D. Student and Special Assistant at Meijo University researching "
+        "Computer Vision, Continual Learning, and Multi-View Tracking."
+    )
+    if stale_literal in header_source:
+        raise SystemExit("Header maintenance still contains a hard-coded current-profile description")
+
     print("OK: social profile description derives from CV roles and affiliation")
 
 

--- a/scripts/maintain_header_controls.py
+++ b/scripts/maintain_header_controls.py
@@ -4,6 +4,7 @@ import re
 
 import maintain_filter_accessibility
 from maintain_asset_versions import main as maintain_asset_versions
+from maintain_social_profile import build_social_description
 
 
 path = Path('index.html')
@@ -20,6 +21,7 @@ if not roles:
     raise SystemExit('assets/cv.txt has an empty role header')
 role_title = roles[0] if len(roles) == 1 else ', '.join(roles[:-1]) + ' & ' + roles[-1]
 page_title = html.escape(f'Taigo Sakai | {role_title}', quote=True)
+social_description = html.escape(build_social_description(cv_text), quote=True)
 
 def replace_title(pattern, replacement, label):
     global text
@@ -41,7 +43,7 @@ twitter_creator = '<meta name="twitter:creator" content="@ikaitaig">'
 twitter_metadata = (
     '<meta name="twitter:creator" content="@ikaitaig">\n'
     f'  <meta name="twitter:title" content="{page_title}">\n'
-    '  <meta name="twitter:description" content="Ph.D. Student and Special Assistant at Meijo University researching Computer Vision, Continual Learning, and Multi-View Tracking.">\n'
+    f'  <meta name="twitter:description" content="{social_description}">\n'
     '  <meta name="twitter:image" content="https://github.com/sakai1250.png">\n'
     '  <meta name="twitter:image:alt" content="Portrait of Taigo Sakai">'
 )


### PR DESCRIPTION
Closes #283.

## What changed
- Reuse `build_social_description()` in `maintain_header_controls.py` instead of embedding the current role and affiliation in Twitter metadata.
- Keep the rendered social description unchanged for the current CV.
- Extend the social-profile regression check so header maintenance must use the shared CV-derived helper and cannot reintroduce the stale current-profile literal.

## Why
This removes an order-dependent maintenance path where running header maintenance independently could restore outdated social-profile text after a role or affiliation change.

## Validation
- Two-file focused diff.
- Existing social-profile check still validates a synthetic `Visiting Researcher / Future University` profile.
- CI should confirm deterministic maintenance and structured-profile checks remain stable.