### PR TITLE
Derive search descriptions from the CV profile

### DIFF
--- a/scripts/check_social_profile_derivation.py
+++ b/scripts/check_social_profile_derivation.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Verify that social profile text follows CV role and affiliation changes."""
+"""Verify that social and search profile text follows CV identity changes."""
 
 from html import escape
 from pathlib import Path
 
-from maintain_social_profile import build_social_description
+from maintain_social_profile import build_search_description, build_social_description
 
 
 def main() -> None:
@@ -14,25 +14,55 @@ Publication name: T. Sakai
 Ph.D. Student | Visiting Researcher | Computer Vision Researcher
 Future University, Tokyo, Japan
 """
-    synthetic_description = build_social_description(synthetic_cv)
-    expected_synthetic = (
+    synthetic_social_description = build_social_description(synthetic_cv)
+    expected_social = (
         "Ph.D. Student and Visiting Researcher at Future University researching "
         "Computer Vision, Continual Learning, and Multi-View Tracking."
     )
-    if synthetic_description != expected_synthetic:
+    if synthetic_social_description != expected_social:
         raise SystemExit(
             "Social description did not follow changed CV role/affiliation: "
-            f"expected={expected_synthetic!r}, actual={synthetic_description!r}"
+            f"expected={expected_social!r}, actual={synthetic_social_description!r}"
         )
-    if "Special Assistant" in synthetic_description or "Meijo University" in synthetic_description:
-        raise SystemExit("Social description retained stale current-profile text")
+
+    synthetic_search_description = build_search_description(synthetic_cv)
+    expected_search = (
+        "Future University 博士後期課程・Visiting Researcher 坂井泰吾のポートフォリオ。"
+        "Computer Vision、Continual Learning、Multi-View Trackingの研究とiOS/Web開発実績を紹介しています。"
+    )
+    if synthetic_search_description != expected_search:
+        raise SystemExit(
+            "Search description did not follow changed CV role/affiliation: "
+            f"expected={expected_search!r}, actual={synthetic_search_description!r}"
+        )
+
+    for description in (synthetic_social_description, synthetic_search_description):
+        if "Special Assistant" in description or "Meijo University" in description or "名城大学" in description:
+            raise SystemExit("Profile description retained stale current-profile text")
 
     cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
     index_text = Path("index.html").read_text(encoding="utf-8")
-    current_description = escape(build_social_description(cv_text), quote=True)
-    expected_tag = f'<meta name="twitter:description" content="{current_description}">'
-    if expected_tag not in index_text:
+
+    current_social_description = escape(build_social_description(cv_text), quote=True)
+    expected_twitter_tag = (
+        f'<meta name="twitter:description" content="{current_social_description}">'
+    )
+    if expected_twitter_tag not in index_text:
         raise SystemExit("Current Twitter description does not match assets/cv.txt")
+
+    current_search_description = escape(build_search_description(cv_text), quote=True)
+    expected_search_tag = (
+        '<meta name="description"\n'
+        f'    content="{current_search_description}">'
+    )
+    expected_og_tag = (
+        '<meta property="og:description"\n'
+        f'    content="{current_search_description}">'
+    )
+    if expected_search_tag not in index_text:
+        raise SystemExit("Current search description does not match assets/cv.txt")
+    if expected_og_tag not in index_text:
+        raise SystemExit("Current Open Graph description does not match assets/cv.txt")
 
     header_source = Path("scripts/maintain_header_controls.py").read_text(encoding="utf-8")
     if "from maintain_social_profile import build_social_description" not in header_source:
@@ -46,7 +76,7 @@ Future University, Tokyo, Japan
     if stale_literal in header_source:
         raise SystemExit("Header maintenance still contains a hard-coded current-profile description")
 
-    print("OK: social profile description derives from CV roles and affiliation")
+    print("OK: social, search, and Open Graph descriptions derive from CV roles and affiliation")
 
 
 if __name__ == "__main__":

--- a/scripts/maintain_social_profile.py
+++ b/scripts/maintain_social_profile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Synchronize social-profile description metadata with the CV role header."""
+"""Synchronize social and search profile metadata with the CV role header."""
 
 from __future__ import annotations
 
@@ -9,6 +9,13 @@ from pathlib import Path
 
 
 RESEARCH_FOCUS = "Computer Vision, Continual Learning, and Multi-View Tracking"
+SEARCH_RESEARCH_FOCUS = "Computer Vision、Continual Learning、Multi-View Tracking"
+ROLE_LABELS_JA = {
+    "Ph.D. Student": "博士後期課程",
+}
+AFFILIATION_LABELS_JA = {
+    "Meijo University": "名城大学大学院",
+}
 
 
 def read_cv_social_profile(cv_text: str) -> tuple[list[str], str]:
@@ -30,17 +37,56 @@ def build_social_description(cv_text: str) -> str:
     return f"{role_phrase} at {affiliation} researching {RESEARCH_FOCUS}."
 
 
+def build_search_description(cv_text: str) -> str:
+    roles, affiliation = read_cv_social_profile(cv_text)
+    visible_roles = roles[:2]
+    localized_roles = [ROLE_LABELS_JA.get(role, role) for role in visible_roles]
+    localized_affiliation = AFFILIATION_LABELS_JA.get(affiliation, affiliation)
+    role_phrase = "・".join(localized_roles)
+    return (
+        f"{localized_affiliation} {role_phrase} 坂井泰吾のポートフォリオ。"
+        f"{SEARCH_RESEARCH_FOCUS}の研究とiOS/Web開発実績を紹介しています。"
+    )
+
+
+def replace_meta(text: str, pattern: re.Pattern[str], replacement: str, label: str) -> str:
+    text, count = pattern.subn(replacement, text, count=1)
+    if count != 1:
+        raise SystemExit(f"Could not find exactly one {label} metadata tag")
+    return text
+
+
 def main() -> None:
     path = Path("index.html")
     text = path.read_text(encoding="utf-8")
     cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
-    description = html.escape(build_social_description(cv_text), quote=True)
+    social_description = html.escape(build_social_description(cv_text), quote=True)
+    search_description = html.escape(build_search_description(cv_text), quote=True)
 
-    pattern = re.compile(r'<meta name="twitter:description" content="[^"]*">')
-    replacement = f'<meta name="twitter:description" content="{description}">'
-    text, count = pattern.subn(replacement, text, count=1)
-    if count != 1:
-        raise SystemExit("Could not find exactly one Twitter description metadata tag")
+    text = replace_meta(
+        text,
+        re.compile(r'<meta name="twitter:description" content="[^"]*">'),
+        f'<meta name="twitter:description" content="{social_description}">',
+        "Twitter description",
+    )
+    text = replace_meta(
+        text,
+        re.compile(
+            r'<meta name="description"\s+content="[^"]*">',
+            flags=re.DOTALL,
+        ),
+        f'<meta name="description"\n    content="{search_description}">',
+        "search description",
+    )
+    text = replace_meta(
+        text,
+        re.compile(
+            r'<meta property="og:description"\s+content="[^"]*">',
+            flags=re.DOTALL,
+        ),
+        f'<meta property="og:description"\n    content="{search_description}">',
+        "Open Graph description",
+    )
 
     path.write_text(text, encoding="utf-8")
 

--- a/scripts/maintain_static_fallbacks.py
+++ b/scripts/maintain_static_fallbacks.py
@@ -12,15 +12,13 @@ import xml.etree.ElementTree as ET
 
 INDEX_PATH = Path("index.html")
 SITEMAP_PATH = Path("sitemap.xml")
-# Track visitor-facing sources and the transforms that can change them. Validation-only
-# check_*.py edits should not make the public portfolio look newly updated.
+# Public "last updated" dates should describe visitor-facing content, not changes to
+# maintenance code that leave the generated page unchanged.
 TRACKED_PAGE_FILES = (
     "index.html",
     "main.js",
     "style.css",
     "assets/data.json",
-    "scripts/maintain_*.py",
-    "scripts/run_deterministic_maintenance.py",
 )
 HOME_URL = "https://sakai1250.github.io/"
 SITE_TIMEZONE = ZoneInfo("Asia/Tokyo")


### PR DESCRIPTION
## Summary
- derive standard search and Open Graph descriptions from `assets/cv.txt`
- keep the current concise Japanese wording for the present Meijo University profile
- use explicit role/affiliation localization maps with readable fallback text for unknown future values
- extend the existing profile-derivation regression check with changed-role and changed-affiliation cases
- keep public `last updated` and sitemap dates tied to visitor-facing content rather than maintenance-only source edits

## Why
This advances #285 by making search snippets and Open Graph previews follow the same CV identity source already used by the visible profile and social metadata. The date-tracking adjustment prevents maintenance-only commits that leave generated HTML unchanged from falsely advertising a new portfolio-content date.

## Validation
The structured-profile workflow runs `scripts/check_social_profile_derivation.py`, including a synthetic `Visiting Researcher / Future University` profile. Static-fallback validation continues to verify the generated footer counts and sitemap metadata.

## Scope
No visual decoration or layout changes. The remaining fixed legacy description path in `maintain_profile_metadata.py` is intentionally left tracked by #285 rather than hidden by this PR.