### PR TITLE
Keep profile description maintenance CV-derived

### DIFF
--- a/scripts/check_social_profile_derivation.py
+++ b/scripts/check_social_profile_derivation.py
@@ -69,12 +69,24 @@ Future University, Tokyo, Japan
         raise SystemExit("Header maintenance does not reuse the CV-derived social description helper")
     if "build_social_description(cv_text)" not in header_source:
         raise SystemExit("Header maintenance does not derive social description from the current CV")
-    stale_literal = (
+    stale_social_literal = (
         "Ph.D. Student and Special Assistant at Meijo University researching "
         "Computer Vision, Continual Learning, and Multi-View Tracking."
     )
-    if stale_literal in header_source:
+    if stale_social_literal in header_source:
         raise SystemExit("Header maintenance still contains a hard-coded current-profile description")
+
+    profile_source = Path("scripts/maintain_profile_metadata.py").read_text(encoding="utf-8")
+    if "from maintain_social_profile import build_search_description" not in profile_source:
+        raise SystemExit("Profile maintenance does not reuse the CV-derived search description helper")
+    if "build_search_description(cv_text)" not in profile_source:
+        raise SystemExit("Profile maintenance does not derive search description from the current CV")
+    stale_search_literal = (
+        "名城大学大学院 博士後期課程・Special Assistant 坂井泰吾のポートフォリオ。"
+        "Computer Vision、Continual Learning、Multi-View Trackingの研究とiOS/Web開発実績を紹介しています。"
+    )
+    if stale_search_literal in profile_source:
+        raise SystemExit("Profile maintenance still contains a hard-coded current-profile search description")
 
     print("OK: social, search, and Open Graph descriptions derive from CV roles and affiliation")
 

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import html
 import re
 
+from maintain_social_profile import build_search_description
+
 
 INDEX_PATH = Path("index.html")
 NOT_FOUND_PATH = Path("404.html")
@@ -114,19 +116,23 @@ def maintain_structured_profile(text: str, profile_urls: list[str], cv_text: str
     if match.group(2) != desired_profiles:
         text = text[: match.start(2)] + desired_profiles + text[match.end(2) :]
 
-    old_description = (
-        "名城大学大学院 博士後期課程 坂井泰吾のポートフォリオ。"
-        "Deep Learning, Computer Visionの研究や、iOS/Webアプリ開発の実績を紹介しています。"
+    desired_description = html.escape(build_search_description(cv_text), quote=True)
+    description_patterns = (
+        (
+            re.compile(r'<meta name="description"\s+content="[^"]*">', flags=re.DOTALL),
+            f'<meta name="description"\n    content="{desired_description}">',
+            "search description",
+        ),
+        (
+            re.compile(r'<meta property="og:description"\s+content="[^"]*">', flags=re.DOTALL),
+            f'<meta property="og:description"\n    content="{desired_description}">',
+            "Open Graph description",
+        ),
     )
-    new_description = (
-        "名城大学大学院 博士後期課程・Special Assistant 坂井泰吾のポートフォリオ。"
-        "Computer Vision、Continual Learning、Multi-View Trackingの研究とiOS/Web開発実績を紹介しています。"
-    )
-    count = text.count(old_description)
-    if count:
-        text = text.replace(old_description, new_description)
-    elif text.count(new_description) < 2:
-        raise SystemExit("Could not find expected profile meta descriptions")
+    for pattern, replacement, label in description_patterns:
+        text, count = pattern.subn(replacement, text, count=1)
+        if count != 1:
+            raise SystemExit(f"Could not find expected {label}")
 
     return text
 


### PR DESCRIPTION
## Summary
- reuse the CV-derived `build_search_description()` helper inside `maintain_profile_metadata.py`
- update both standard search and Open Graph descriptions without relying on the later social-profile maintenance step
- extend the social-profile regression check so hard-coded current-role search text cannot be reintroduced

## Why
`maintain_social_profile.py` already derives search metadata from `assets/cv.txt`, but `maintain_profile_metadata.py` could still restore the old Meijo University / Special Assistant description when run by itself. This removes that execution-order dependency while preserving the current public wording.

## Validation target
- changed role/affiliation fixtures continue to produce changed search metadata
- current search and Open Graph descriptions remain unchanged
- deterministic maintenance stays idempotent

Closes #285