### PR TITLE
Localize contextual share text

### DIFF
--- a/scripts/maintain_contextual_share_link.py
+++ b/scripts/maintain_contextual_share_link.py
@@ -11,15 +11,18 @@ if init_line not in js:
         raise SystemExit("Could not find expected initialization anchor")
     js = js.replace(init_anchor, init_anchor + init_line, 1)
 
-share_function = r'''
-function initContextualShareLink() {
+share_function = r'''function initContextualShareLink() {
     const link = document.getElementById('share-btn');
     if (!link) return;
 
     const sync = () => {
         const pageUrl = `${window.location.origin}${window.location.pathname}${window.location.search}${window.location.hash}`;
+        const lang = document.documentElement.dataset.lang === 'en' ? 'en' : 'ja';
+        const shareText = lang === 'ja'
+            ? '坂井泰吾のポートフォリオです。'
+            : "Check out Taigo Sakai's Portfolio!";
         const params = new URLSearchParams({
-            text: "Check out Taigo Sakai's Portfolio!",
+            text: shareText,
             url: pageUrl,
             via: 'ikaitaig'
         });
@@ -34,16 +37,26 @@ function initContextualShareLink() {
 }
 '''
 
-if "function initContextualShareLink() {" not in js:
+function_start = js.find("function initContextualShareLink() {")
+if function_start == -1:
     marker = "\n// === Core Functions ===\n"
     if marker not in js:
         raise SystemExit("Could not find core function marker")
-    js = js.replace(marker, marker + share_function + "\n", 1)
+    js = js.replace(marker, marker + "\n" + share_function + "\n", 1)
+else:
+    next_function = js.find("\n\nfunction ", function_start + 1)
+    if next_function == -1:
+        raise SystemExit("Could not find the end of contextual share function")
+    js = js[:function_start] + share_function.rstrip() + js[next_function:]
 
 for marker in (
     "safeInit(initContextualShareLink, 'ContextualShareLink');",
     "const pageUrl = `${window.location.origin}${window.location.pathname}${window.location.search}${window.location.hash}`;",
-    "new URLSearchParams({",
+    "document.documentElement.dataset.lang === 'en' ? 'en' : 'ja'",
+    "'坂井泰吾のポートフォリオです。'",
+    '"Check out Taigo Sakai\'s Portfolio!"',
+    "text: shareText,",
+    "via: 'ikaitaig'",
     "link.addEventListener('click', sync);",
     "window.addEventListener('hashchange', sync);",
 ):


### PR DESCRIPTION
## Summary
- derive the X/Twitter share message from the current Japanese or English portfolio view
- keep the current deep-link URL, `via=ikaitaig`, and existing share interaction behavior
- make the maintenance script replace the existing generated share function, so future deterministic maintenance can actually update `main.js` instead of only inserting the function when missing

## Why
This closes the language mismatch tracked in #290 without adding UI or new sharing services.

## Validation plan
After merge, the existing `Optimize Portfolio Assets` workflow will run deterministic maintenance on `main`, regenerate `main.js`, and commit the generated change. A follow-up regression guard will be added once that generated output is present on `main`.