### PR TITLE
Localize landmark and filter accessible names

### DIFF
--- a/scripts/maintain_localized_landmark_labels.py
+++ b/scripts/maintain_localized_landmark_labels.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Keep landmark and filter accessible names aligned with the active page language."""
+
+from pathlib import Path
+
+
+html_path = Path("index.html")
+html = html_path.read_text(encoding="utf-8")
+
+label_replacements = {
+    '<nav class="tab-nav header-tab-nav" aria-label="Research and engineering / 研究と開発">': (
+        '<nav class="tab-nav header-tab-nav" aria-label="研究と開発" '
+        'data-ja-aria-label="研究と開発" data-en-aria-label="Research and engineering">'
+    ),
+    '<div class="filter-row year-filter" role="group" aria-label="Filter research outputs by year / 研究業績を年度で絞り込む">': (
+        '<div class="filter-row year-filter" role="group" aria-label="研究業績を年度で絞り込む" '
+        'data-ja-aria-label="研究業績を年度で絞り込む" '
+        'data-en-aria-label="Filter research outputs by year">'
+    ),
+    '<div class="filter-row" role="group" aria-label="Filter engineering work / 開発実績を絞り込む">': (
+        '<div class="filter-row" role="group" aria-label="開発実績を絞り込む" '
+        'data-ja-aria-label="開発実績を絞り込む" '
+        'data-en-aria-label="Filter engineering work">'
+    ),
+    '<nav id="section-tab-nav" class="section-tab-nav" aria-label="Portfolio sections / ポートフォリオ内の項目"></nav>': (
+        '<nav id="section-tab-nav" class="section-tab-nav" aria-label="ポートフォリオ内の項目" '
+        'data-ja-aria-label="ポートフォリオ内の項目" '
+        'data-en-aria-label="Portfolio sections"></nav>'
+    ),
+}
+
+for mixed, localized in label_replacements.items():
+    if localized in html:
+        continue
+    if mixed not in html:
+        raise SystemExit(f"Could not find landmark label to localize: {mixed}")
+    html = html.replace(mixed, localized, 1)
+
+for mixed in label_replacements:
+    if mixed in html:
+        raise SystemExit(f"Mixed-language accessible name remains: {mixed}")
+
+html_path.write_text(html, encoding="utf-8")
+
+js_path = Path("main.js")
+js = js_path.read_text(encoding="utf-8")
+
+safe_init_anchor = "    safeInit(initLanguage, 'Language');\n"
+safe_init_line = "    safeInit(initLocalizedAccessibleNames, 'LocalizedAccessibleNames');\n"
+if safe_init_line not in js:
+    if safe_init_anchor not in js:
+        raise SystemExit("Could not find language initialization anchor")
+    js = js.replace(safe_init_anchor, safe_init_anchor + safe_init_line, 1)
+
+function_anchor = "function initContextualShareLink() {\n"
+localized_function = """function initLocalizedAccessibleNames() {
+    const sync = () => {
+        const lang = document.documentElement.dataset.lang === 'en' ? 'en' : 'ja';
+        document.querySelectorAll('[data-ja-aria-label][data-en-aria-label]').forEach(element => {
+            const label = lang === 'en' ? element.dataset.enAriaLabel : element.dataset.jaAriaLabel;
+            if (label) element.setAttribute('aria-label', label);
+        });
+    };
+
+    window.addEventListener('portfolio:languagechange', sync);
+    sync();
+}
+
+"""
+if localized_function not in js:
+    if function_anchor not in js:
+        raise SystemExit("Could not find JavaScript function insertion anchor")
+    js = js.replace(function_anchor, localized_function + function_anchor, 1)
+
+required_js = (
+    "safeInit(initLocalizedAccessibleNames, 'LocalizedAccessibleNames')",
+    "document.querySelectorAll('[data-ja-aria-label][data-en-aria-label]')",
+    "window.addEventListener('portfolio:languagechange', sync)",
+    "element.dataset.enAriaLabel",
+    "element.dataset.jaAriaLabel",
+)
+missing = [marker for marker in required_js if marker not in js]
+if missing:
+    raise SystemExit(f"Localized accessible-name synchronization is incomplete: {missing}")
+
+js_path.write_text(js, encoding="utf-8")

--- a/scripts/prepare_localized_landmark_maintenance.py
+++ b/scripts/prepare_localized_landmark_maintenance.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Normalize localized landmark labels for older maintenance transforms."""
+
+from pathlib import Path
+
+
+path = Path("index.html")
+text = path.read_text(encoding="utf-8")
+
+compatibility = {
+    '<nav class="tab-nav header-tab-nav" aria-label="研究と開発" data-ja-aria-label="研究と開発" data-en-aria-label="Research and engineering">': (
+        '<nav class="tab-nav header-tab-nav" aria-label="Research and engineering / 研究と開発">'
+    ),
+    '<div class="filter-row year-filter" role="group" aria-label="研究業績を年度で絞り込む" data-ja-aria-label="研究業績を年度で絞り込む" data-en-aria-label="Filter research outputs by year">': (
+        '<div class="filter-row year-filter" role="group" aria-label="Filter research outputs by year / 研究業績を年度で絞り込む">'
+    ),
+    '<div class="filter-row" role="group" aria-label="開発実績を絞り込む" data-ja-aria-label="開発実績を絞り込む" data-en-aria-label="Filter engineering work">': (
+        '<div class="filter-row" role="group" aria-label="Filter engineering work / 開発実績を絞り込む">'
+    ),
+    '<nav id="section-tab-nav" class="section-tab-nav" aria-label="ポートフォリオ内の項目" data-ja-aria-label="ポートフォリオ内の項目" data-en-aria-label="Portfolio sections"></nav>': (
+        '<nav id="section-tab-nav" class="section-tab-nav" aria-label="Portfolio sections / ポートフォリオ内の項目"></nav>'
+    ),
+}
+
+for localized, legacy in compatibility.items():
+    if localized in text:
+        text = text.replace(localized, legacy, 1)
+
+path.write_text(text, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -17,6 +17,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_tabs.py",
     "scripts/maintain_stable_section_ids.py",
     "scripts/maintain_contact_form.py",
+    "scripts/prepare_localized_landmark_maintenance.py",
     "scripts/prepare_header_section_reordering.py",
     "scripts/maintain_header_controls.py",
     "scripts/maintain_social_profile.py",

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -30,6 +30,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_theme_preference_persistence.py",
     "scripts/maintain_theme_toggle_accessibility.py",
     "scripts/maintain_language_toggle_accessibility.py",
+    "scripts/maintain_localized_landmark_labels.py",
     "scripts/maintain_external_links.py",
     "scripts/maintain_resource_link_accessibility.py",
     "scripts/maintain_reduced_motion.py",


### PR DESCRIPTION
Closes #294

## What changed
- adds deterministic maintenance for the remaining bilingual landmark/group `aria-label` values
- keeps Japanese labels as the static fallback
- stores Japanese and English accessible-name sources on each affected element
- synchronizes the active `aria-label` with the current portfolio language and updates it after language changes
- wires the transform into deterministic maintenance

## Why
The visible site already switches languages, but screen readers still announced both languages for primary navigation, year filtering, engineering filtering, and in-page section navigation. This keeps the spoken UI consistent without changing the visible layout or navigation behavior.