### PR TITLE
Validate specialized profile checks after optimization

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -53,6 +53,8 @@ jobs:
         run: node --check main.js
       - name: Validate site integrity
         run: python scripts/check_site_integrity.py
+      - name: Validate contextual share localization
+        run: python scripts/check_contextual_share_localization.py
       - name: Validate interactive accessible names
         run: python scripts/check_control_accessible_names.py
       - name: Validate form control names
@@ -69,6 +71,10 @@ jobs:
         run: python scripts/check_app_repo_links.py
       - name: Validate structured profile
         run: python scripts/check_structured_profile.py
+      - name: Validate CV-derived sidebar roles
+        run: python scripts/check_sidebar_role_derivation.py
+      - name: Validate CV-derived social profile
+        run: python scripts/check_social_profile_derivation.py
       - name: Validate machine-readable profile
         run: python scripts/check_llms_profile.py
       - name: Validate security contact

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ python3.14 -m py_compile scripts/*.py
 node --check main.js
 python3.14 scripts/run_deterministic_maintenance.py
 python3.14 scripts/check_app_repo_links.py
+python3.14 scripts/check_contextual_share_localization.py
 python3.14 scripts/check_local_deep_links.py
 python3.14 scripts/check_site_integrity.py
 python3.14 scripts/check_control_accessible_names.py
@@ -56,6 +57,8 @@ python3.14 scripts/check_new_tab_link_security.py
 python3.14 scripts/check_progressive_enhancement.py
 python3.14 scripts/check_security_contact.py
 python3.14 scripts/check_structured_profile.py
+python3.14 scripts/check_sidebar_role_derivation.py
+python3.14 scripts/check_social_profile_derivation.py
 python3.14 scripts/check_llms_profile.py
 python3.14 scripts/check_year_filter_coverage.py
 git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md llms.txt SECURITY.md .well-known/security.txt


### PR DESCRIPTION
## Why
The post-optimization workflow validates the generated `main` branch, but it did not run three specialized checks that already protect normal pushes and pull requests:

- contextual share localization
- CV-derived sidebar roles
- CV-derived social profile metadata

Because portfolio optimization can commit generated files itself, the final generated state should not rely on a separate push-triggered workflow to cover these invariants.

## Changes
- run the three specialized checks in post-optimization validation
- add the same commands to the README local-validation sequence

## Scope
No visible portfolio content or interaction behavior changes. This only closes a validation gap around generated state.