### PR TITLE
Keep HCV2026 award label aligned with the CV

### DIFF
--- a/.github/workflows/site-integrity.yml
+++ b/.github/workflows/site-integrity.yml
@@ -26,8 +26,8 @@ jobs:
         run: node --check main.js
       - name: Check links, accessibility basics, generated data, CV text, and indexing files
         run: python scripts/check_site_integrity.py
-      - name: Check research award alignment
-        run: python scripts/check_research_award_alignment.py
+      - name: Check research award source alignment
+        run: python scripts/check_research_award_alignment.py --source-only
       - name: Check contextual share localization
         run: python scripts/check_contextual_share_localization.py
       - name: Check interactive control names

--- a/.github/workflows/site-integrity.yml
+++ b/.github/workflows/site-integrity.yml
@@ -26,6 +26,8 @@ jobs:
         run: node --check main.js
       - name: Check links, accessibility basics, generated data, CV text, and indexing files
         run: python scripts/check_site_integrity.py
+      - name: Check research award alignment
+        run: python scripts/check_research_award_alignment.py
       - name: Check contextual share localization
         run: python scripts/check_contextual_share_localization.py
       - name: Check interactive control names

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -53,6 +53,8 @@ jobs:
         run: node --check main.js
       - name: Validate site integrity
         run: python scripts/check_site_integrity.py
+      - name: Validate research award alignment
+        run: python scripts/check_research_award_alignment.py
       - name: Validate contextual share localization
         run: python scripts/check_contextual_share_localization.py
       - name: Validate interactive accessible names

--- a/scripts/check_research_award_alignment.py
+++ b/scripts/check_research_award_alignment.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Guard the public HCV2026 award label against CV/source drift."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CV = (ROOT / "assets/cv.txt").read_text(encoding="utf-8")
+INDEX = (ROOT / "index.html").read_text(encoding="utf-8")
+MAINTENANCE = (ROOT / "scripts/maintain_research_awards.py").read_text(encoding="utf-8")
+
+AWARD_LINE = "- HCV2026 Outstanding Paper Award - 2026"
+PUBLIC_LABEL = "HCV2026 Outstanding Paper Award"
+LEGACY_LABELS = (
+    "ECCV 2026 Human-inspired Computer Vision Workshop Outstanding Paper Award",
+    "ECCV 2026 Human-inspired Computer Vision Workshop, Outstanding Paper Award",
+)
+
+if AWARD_LINE not in CV:
+    raise SystemExit("assets/cv.txt: HCV2026 award entry is missing")
+
+if INDEX.count(f">{PUBLIC_LABEL}</span>") < 2:
+    raise SystemExit("index.html: Japanese and English HCV2026 award labels are not aligned with the CV")
+
+for legacy in LEGACY_LABELS:
+    if legacy in INDEX:
+        raise SystemExit(f"index.html: expanded legacy HCV2026 award label remains: {legacy}")
+
+if 'HCV_AWARD_LABEL = "HCV2026 Outstanding Paper Award"' not in MAINTENANCE:
+    raise SystemExit("maintain_research_awards.py: CV-aligned public award label is not guarded at source")
+
+print("OK: HCV2026 award label is aligned across CV, public page, and maintenance source")

--- a/scripts/check_research_award_alignment.py
+++ b/scripts/check_research_award_alignment.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Guard the public HCV2026 award label against CV/source drift."""
+"""Guard the HCV2026 award label against CV/source and generated-page drift."""
 
 from pathlib import Path
+import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 CV = (ROOT / "assets/cv.txt").read_text(encoding="utf-8")
@@ -14,18 +15,22 @@ LEGACY_LABELS = (
     "ECCV 2026 Human-inspired Computer Vision Workshop Outstanding Paper Award",
     "ECCV 2026 Human-inspired Computer Vision Workshop, Outstanding Paper Award",
 )
+SOURCE_ONLY = "--source-only" in sys.argv[1:]
 
 if AWARD_LINE not in CV:
     raise SystemExit("assets/cv.txt: HCV2026 award entry is missing")
 
-if INDEX.count(f">{PUBLIC_LABEL}</span>") < 2:
-    raise SystemExit("index.html: Japanese and English HCV2026 award labels are not aligned with the CV")
-
-for legacy in LEGACY_LABELS:
-    if legacy in INDEX:
-        raise SystemExit(f"index.html: expanded legacy HCV2026 award label remains: {legacy}")
-
 if 'HCV_AWARD_LABEL = "HCV2026 Outstanding Paper Award"' not in MAINTENANCE:
     raise SystemExit("maintain_research_awards.py: CV-aligned public award label is not guarded at source")
 
-print("OK: HCV2026 award label is aligned across CV, public page, and maintenance source")
+if not SOURCE_ONLY:
+    if INDEX.count(f">{PUBLIC_LABEL}</span>") < 2:
+        raise SystemExit("index.html: Japanese and English HCV2026 award labels are not aligned with the CV")
+
+    for legacy in LEGACY_LABELS:
+        if legacy in INDEX:
+            raise SystemExit(f"index.html: expanded legacy HCV2026 award label remains: {legacy}")
+
+    print("OK: HCV2026 award label is aligned across CV, public page, and maintenance source")
+else:
+    print("OK: HCV2026 award source is aligned with the machine-readable CV")

--- a/scripts/maintain_research_awards.py
+++ b/scripts/maintain_research_awards.py
@@ -19,13 +19,15 @@ HCV_PUBLICATION_WITH_AWARD = (
     'NeuroGuard: Neural Gradient Update Aware of Representation Damage,”\n'
     '                  <div class="muted">ECCV 2026 Workshop on Human-inspired Computer Vision, Oral, Outstanding Paper Award, Malmö, Sweden.</div>'
 )
-HCV_AWARD_ITEM = """                <li data-year="2026"><span class="badge-year">2026</span>
-                  <span lang="ja">ECCV 2026 Human-inspired Computer Vision Workshop Outstanding Paper Award</span>
-                  <span lang="en">ECCV 2026 Human-inspired Computer Vision Workshop, Outstanding Paper Award</span>
+HCV_AWARD_LABEL = "HCV2026 Outstanding Paper Award"
+HCV_AWARD_ITEM = f"""                <li data-year="2026"><span class="badge-year">2026</span>
+                  <span lang="ja">{HCV_AWARD_LABEL}</span>
+                  <span lang="en">{HCV_AWARD_LABEL}</span>
                 </li>
 """
-HCV_AWARD_VISIBLE_MARKER = (
-    "ECCV 2026 Human-inspired Computer Vision Workshop, Outstanding Paper Award"
+HCV_AWARD_LEGACY_LABELS = (
+    "ECCV 2026 Human-inspired Computer Vision Workshop Outstanding Paper Award",
+    "ECCV 2026 Human-inspired Computer Vision Workshop, Outstanding Paper Award",
 )
 
 
@@ -50,13 +52,17 @@ def maintain_hcv_award(text: str, cv_text: str) -> str:
         raise SystemExit("Could not find the public Awards section")
 
     awards = match.group(2)
-    if HCV_AWARD_VISIBLE_MARKER not in awards:
+    for legacy_label in HCV_AWARD_LEGACY_LABELS:
+        awards = awards.replace(legacy_label, HCV_AWARD_LABEL)
+
+    if HCV_AWARD_LABEL not in awards:
         awards = HCV_AWARD_ITEM + awards
-        text = text[: match.start(2)] + awards + text[match.end(2) :]
-        match = awards_pattern.search(text)
-        if not match:
-            raise SystemExit("Awards section became invalid after HCV2026 insertion")
-        awards = match.group(2)
+
+    text = text[: match.start(2)] + awards + text[match.end(2) :]
+    match = awards_pattern.search(text)
+    if not match:
+        raise SystemExit("Awards section became invalid after HCV2026 synchronization")
+    awards = match.group(2)
 
     award_count = len(re.findall(r'<li\b[^>]*data-year="\d{4}"', awards))
     text, count = re.subn(


### PR DESCRIPTION
Keep the visible HCV2026 award name identical to the machine-readable CV instead of expanding it to a different workshop label.

Changes:
- Use `HCV2026 Outstanding Paper Award` for both Japanese and English public labels.
- Migrate the previously generated expanded label during deterministic maintenance.
- Preserve the NeuroGuard award annotation and dynamic award count.
- Add dedicated regression coverage in normal site integrity and post-optimization validation.

Closes #301.