### PR TITLE
Tie HCV2026 award validation to NeuroGuard

### DIFF
--- a/scripts/check_research_award_alignment.py
+++ b/scripts/check_research_award_alignment.py
@@ -10,6 +10,10 @@ INDEX = (ROOT / "index.html").read_text(encoding="utf-8")
 MAINTENANCE = (ROOT / "scripts/maintain_research_awards.py").read_text(encoding="utf-8")
 
 AWARD_LINE = "- HCV2026 Outstanding Paper Award - 2026"
+NEUROGUARD_AWARD_LINE = (
+    '1. T. Sakai, K. Hotta. "NeuroGuard: Neural Gradient Update Aware of Representation Damage." '
+    'ECCV 2026 Workshop on Human-inspired Computer Vision - Oral, Outstanding Paper Award.'
+)
 PUBLIC_LABEL = "HCV2026 Outstanding Paper Award"
 LEGACY_LABELS = (
     "ECCV 2026 Human-inspired Computer Vision Workshop Outstanding Paper Award",
@@ -20,17 +24,26 @@ SOURCE_ONLY = "--source-only" in sys.argv[1:]
 if AWARD_LINE not in CV:
     raise SystemExit("assets/cv.txt: HCV2026 award entry is missing")
 
+if NEUROGUARD_AWARD_LINE not in CV:
+    raise SystemExit("assets/cv.txt: HCV2026 award is not tied to the NeuroGuard publication entry")
+
 if 'HCV_AWARD_LABEL = "HCV2026 Outstanding Paper Award"' not in MAINTENANCE:
     raise SystemExit("maintain_research_awards.py: CV-aligned public award label is not guarded at source")
+
+if "HCV_CV_PUBLICATION_LINE" not in MAINTENANCE:
+    raise SystemExit("maintain_research_awards.py: NeuroGuard-specific CV award validation is missing")
 
 if not SOURCE_ONLY:
     if INDEX.count(f">{PUBLIC_LABEL}</span>") < 2:
         raise SystemExit("index.html: Japanese and English HCV2026 award labels are not aligned with the CV")
 
+    if "NeuroGuard: Neural Gradient Update Aware of Representation Damage" not in INDEX or "Oral, Outstanding Paper Award, Malmö, Sweden." not in INDEX:
+        raise SystemExit("index.html: HCV2026 award is not attached to the NeuroGuard publication entry")
+
     for legacy in LEGACY_LABELS:
         if legacy in INDEX:
             raise SystemExit(f"index.html: expanded legacy HCV2026 award label remains: {legacy}")
 
-    print("OK: HCV2026 award label is aligned across CV, public page, and maintenance source")
+    print("OK: HCV2026 award is tied to NeuroGuard across CV, public page, and maintenance source")
 else:
-    print("OK: HCV2026 award source is aligned with the machine-readable CV")
+    print("OK: HCV2026 award source is tied to the NeuroGuard publication entry")

--- a/scripts/maintain_research_awards.py
+++ b/scripts/maintain_research_awards.py
@@ -11,6 +11,10 @@ INDEX = ROOT / "index.html"
 CV = ROOT / "assets/cv.txt"
 
 HCV_AWARD_LINE = "- HCV2026 Outstanding Paper Award - 2026"
+HCV_CV_PUBLICATION_LINE = (
+    '1. T. Sakai, K. Hotta. "NeuroGuard: Neural Gradient Update Aware of Representation Damage." '
+    'ECCV 2026 Workshop on Human-inspired Computer Vision - Oral, Outstanding Paper Award.'
+)
 HCV_PUBLICATION_MARKER = (
     'NeuroGuard: Neural Gradient Update Aware of Representation Damage,”\n'
     '                  <div class="muted">ECCV 2026 Workshop on Human-inspired Computer Vision, Oral, Malmö, Sweden.</div>'
@@ -52,7 +56,7 @@ def maintain_hcv_award(text: str, cv_text: str) -> str:
     if HCV_AWARD_LINE not in cv_text:
         return text
 
-    if "Outstanding Paper Award." not in cv_text:
+    if HCV_CV_PUBLICATION_LINE not in cv_text:
         raise SystemExit("HCV2026 award is listed in the CV but missing from the NeuroGuard publication entry")
 
     if HCV_PUBLICATION_WITH_AWARD not in text:


### PR DESCRIPTION
The HCV2026 award source check currently accepts any `Outstanding Paper Award.` occurrence in the CV. That can become a false positive when another publication later receives an award with the same wording.

This change:
- validates the exact NeuroGuard CV publication entry before publishing the HCV2026 award;
- extends the regression check so the generated page must attach the award to NeuroGuard;
- keeps the existing public award label and count behavior unchanged.

Closes #304.