### PR TITLE
Expose app details as an accessible dialog

### DIFF
--- a/scripts/maintain_modal_accessibility.py
+++ b/scripts/maintain_modal_accessibility.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Keep the app detail modal exposed as an accessible dialog."""
+
+from pathlib import Path
+
+
+path = Path("index.html")
+text = path.read_text(encoding="utf-8")
+
+legacy = '<div class="modal-container" tabindex="-1">'
+accessible = (
+    '<div class="modal-container" tabindex="-1" role="dialog" '
+    'aria-modal="true" aria-labelledby="modal-title">'
+)
+
+if legacy in text:
+    text = text.replace(legacy, accessible, 1)
+elif accessible not in text:
+    raise SystemExit("Could not find the app modal container")
+
+required = (
+    'role="dialog"',
+    'aria-modal="true"',
+    'aria-labelledby="modal-title"',
+    'id="modal-title"',
+)
+for marker in required:
+    if marker not in text:
+        raise SystemExit(f"App modal is missing accessible dialog marker: {marker}")
+
+if text.count(accessible) != 1:
+    raise SystemExit("Expected exactly one accessible app modal container")
+
+path.write_text(text, encoding="utf-8")

--- a/scripts/run_deterministic_maintenance.py
+++ b/scripts/run_deterministic_maintenance.py
@@ -35,6 +35,7 @@ MAINTENANCE_SCRIPTS = (
     "scripts/maintain_language_toggle_accessibility.py",
     "scripts/maintain_localized_landmark_labels.py",
     "scripts/maintain_utility_control_localization.py",
+    "scripts/maintain_modal_accessibility.py",
     "scripts/maintain_external_links.py",
     "scripts/maintain_resource_link_accessibility.py",
     "scripts/maintain_reduced_motion.py",


### PR DESCRIPTION
## Summary

- add deterministic maintenance that marks the app detail container as `role="dialog"`
- expose it as modal with `aria-modal="true"`
- associate the dialog with the dynamic `#modal-title`
- keep the existing focus, close-button, Escape-key, and focus-return behavior unchanged

## Why

The overlay already behaves like a dialog for keyboard users, but assistive technology currently sees only nested `div` elements. This change adds the missing semantic relationship without changing the visible UI.

Closes #306.