### PR TITLE
Stabilize optimizer-derived update dates

### DIFF
--- a/scripts/maintain_static_fallbacks.py
+++ b/scripts/maintain_static_fallbacks.py
@@ -74,10 +74,20 @@ def effective_git_update_timestamp(tracked_file: str) -> datetime | None:
 
     parent_timestamp = parse_git_timestamp(parent_value, "optimizer parent")
     elapsed = timestamp - parent_timestamp
-    if timedelta(0) <= elapsed <= OPTIMIZER_PARENT_WINDOW:
-        return parent_timestamp
+    if not (timedelta(0) <= elapsed <= OPTIMIZER_PARENT_WINDOW):
+        return timestamp
 
-    return timestamp
+    previous_result = subprocess.run(
+        ["git", "log", "-1", "--format=%cI", f"{commit_sha}^", "--", tracked_file],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    previous_value = previous_result.stdout.strip()
+    if previous_value:
+        return parse_git_timestamp(previous_value, "previous content update")
+
+    return parent_timestamp
 
 
 def git_update_date(*tracked_files: str) -> str:

--- a/scripts/maintain_static_fallbacks.py
+++ b/scripts/maintain_static_fallbacks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Keep visible portfolio fallback counts and sitemap update dates aligned."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 import html
@@ -22,6 +22,8 @@ TRACKED_PAGE_FILES = (
 )
 HOME_URL = "https://sakai1250.github.io/"
 SITE_TIMEZONE = ZoneInfo("Asia/Tokyo")
+OPTIMIZER_COMMIT_MESSAGE = "chore: update portfolio assets and optimized images"
+OPTIMIZER_PARENT_WINDOW = timedelta(minutes=30)
 STATIC_SITEMAP_FILES = {
     "https://sakai1250.github.io/assets/cv.pdf": "assets/cv.pdf",
     "https://sakai1250.github.io/assets/cv.txt": "assets/cv.txt",
@@ -30,23 +32,59 @@ STATIC_SITEMAP_FILES = {
 QIITA_FALLBACK = '''<li><a href="https://qiita.com/sakai1250" target="_blank" rel="noopener noreferrer"><span lang="ja">Qiitaプロフィールを見る</span><span lang="en">Open Qiita profile</span></a></li>'''
 
 
+def parse_git_timestamp(value: str, label: str) -> datetime:
+    try:
+        timestamp = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SystemExit(f"Unexpected {label} timestamp: {value}") from exc
+    if timestamp.tzinfo is None:
+        raise SystemExit(f"{label.capitalize()} timestamp has no timezone: {value}")
+    return timestamp
+
+
+def effective_git_update_timestamp(tracked_file: str) -> datetime | None:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%H%x1f%cI%x1f%s", "--", tracked_file],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    value = result.stdout.strip()
+    if not value:
+        return None
+
+    try:
+        commit_sha, timestamp_value, subject = value.split("\x1f", 2)
+    except ValueError as exc:
+        raise SystemExit(f"Unexpected git log record for {tracked_file}: {value}") from exc
+
+    timestamp = parse_git_timestamp(timestamp_value, "source update")
+    if subject != OPTIMIZER_COMMIT_MESSAGE:
+        return timestamp
+
+    parent_result = subprocess.run(
+        ["git", "show", "-s", "--format=%cI", f"{commit_sha}^"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    parent_value = parent_result.stdout.strip()
+    if not parent_value:
+        return timestamp
+
+    parent_timestamp = parse_git_timestamp(parent_value, "optimizer parent")
+    elapsed = timestamp - parent_timestamp
+    if timedelta(0) <= elapsed <= OPTIMIZER_PARENT_WINDOW:
+        return parent_timestamp
+
+    return timestamp
+
+
 def git_update_date(*tracked_files: str) -> str:
     dates = []
     for tracked_file in tracked_files:
-        result = subprocess.run(
-            ["git", "log", "-1", "--format=%cI", "--", tracked_file],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        value = result.stdout.strip()
-        if value:
-            try:
-                timestamp = datetime.fromisoformat(value)
-            except ValueError as exc:
-                raise SystemExit(f"Unexpected source update timestamp: {value}") from exc
-            if timestamp.tzinfo is None:
-                raise SystemExit(f"Source update timestamp has no timezone: {value}")
+        timestamp = effective_git_update_timestamp(tracked_file)
+        if timestamp is not None:
             dates.append(timestamp.astimezone(SITE_TIMEZONE).date())
 
     if not dates:


### PR DESCRIPTION
## Summary

Fix the non-idempotent portfolio freshness date that caused the latest post-optimization validation to fail across the JST midnight boundary.

## Change

- Detect the optimizer-generated `chore: update portfolio assets and optimized images` commit when resolving a tracked file's update timestamp.
- If that generated commit immediately follows its triggering parent within 30 minutes, use the parent timestamp as the visitor-facing content date.
- Keep the generated commit's own timestamp for autonomous optimizer changes whose parent is older, so scheduled content refreshes still receive a current date.

## Why

The optimizer runs deterministic maintenance before creating its generated commit. A validation pass after that commit must produce the same files. Using the generated commit's timestamp made the footer and sitemap change again when the generated commit crossed midnight in `Asia/Tokyo`.

This keeps researcher/recruiter-facing freshness metadata meaningful while restoring deterministic maintenance reliability.

Closes #308.