### PR TITLE
Keep app modal semantics on one dialog

### DIFF
--- a/scripts/maintain_modal_accessibility.py
+++ b/scripts/maintain_modal_accessibility.py
@@ -1,34 +1,68 @@
 #!/usr/bin/env python3
-"""Keep the app detail modal exposed as an accessible dialog."""
+"""Keep the app detail modal exposed as one accessible dialog."""
 
 from pathlib import Path
 
 
-path = Path("index.html")
-text = path.read_text(encoding="utf-8")
+html_path = Path("index.html")
+html = html_path.read_text(encoding="utf-8")
 
 legacy = '<div class="modal-container" tabindex="-1">'
-accessible = (
+labelled = (
     '<div class="modal-container" tabindex="-1" role="dialog" '
     'aria-modal="true" aria-labelledby="modal-title">'
 )
+accessible = (
+    '<div class="modal-container" tabindex="-1" role="dialog" '
+    'aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-desc">'
+)
 
-if legacy in text:
-    text = text.replace(legacy, accessible, 1)
-elif accessible not in text:
+if legacy in html:
+    html = html.replace(legacy, accessible, 1)
+elif labelled in html:
+    html = html.replace(labelled, accessible, 1)
+elif accessible not in html:
     raise SystemExit("Could not find the app modal container")
 
-required = (
+required_html = (
     'role="dialog"',
     'aria-modal="true"',
     'aria-labelledby="modal-title"',
+    'aria-describedby="modal-desc"',
     'id="modal-title"',
+    'id="modal-desc"',
 )
-for marker in required:
-    if marker not in text:
+for marker in required_html:
+    if marker not in html:
         raise SystemExit(f"App modal is missing accessible dialog marker: {marker}")
 
-if text.count(accessible) != 1:
+if html.count(accessible) != 1:
     raise SystemExit("Expected exactly one accessible app modal container")
 
-path.write_text(text, encoding="utf-8")
+html_path.write_text(html, encoding="utf-8")
+
+js_path = Path("main.js")
+js = js_path.read_text(encoding="utf-8")
+
+runtime_attributes = (
+    ("role", "dialog"),
+    ("aria-modal", "true"),
+    ("aria-labelledby", "modal-title"),
+    ("aria-describedby", "modal-desc"),
+)
+for attribute, value in runtime_attributes:
+    overlay = f"    modal.setAttribute('{attribute}', '{value}');"
+    dialog = f"    dialog?.setAttribute('{attribute}', '{value}');"
+    if overlay in js:
+        js = js.replace(overlay, dialog, 1)
+    elif dialog not in js:
+        raise SystemExit(f"Could not find runtime app dialog attribute: {attribute}")
+
+if "modal.setAttribute('role', 'dialog');" in js:
+    raise SystemExit("App modal overlay must not expose duplicate dialog semantics")
+for attribute, value in runtime_attributes:
+    marker = f"dialog?.setAttribute('{attribute}', '{value}');"
+    if marker not in js:
+        raise SystemExit(f"App modal container is missing runtime attribute: {attribute}")
+
+js_path.write_text(js, encoding="utf-8")


### PR DESCRIPTION
## Summary

- keep the outer modal overlay responsible for visibility state only
- attach `role="dialog"`, `aria-modal`, `aria-labelledby`, and `aria-describedby` to `.modal-container`
- make deterministic maintenance rewrite the runtime attributes onto the same dialog element
- fail maintenance if duplicate dialog semantics return

## Why

The current HTML marks `.modal-container` as a dialog, but `initModals()` also marks `.modal-overlay` as a dialog at runtime. That creates nested dialog semantics for one app-detail modal and can confuse assistive technology.

Closes #310.