### PR TITLE
Keep app dialog accessibility idempotent

### DIFF
--- a/scripts/maintain_modal_accessibility.py
+++ b/scripts/maintain_modal_accessibility.py
@@ -2,42 +2,51 @@
 """Keep the app detail modal exposed as one accessible dialog."""
 
 from pathlib import Path
+import re
 
 
 html_path = Path("index.html")
 html = html_path.read_text(encoding="utf-8")
 
-legacy = '<div class="modal-container" tabindex="-1">'
-labelled = (
+inner_plain = '<div class="modal-container" tabindex="-1">'
+inner_labelled = (
     '<div class="modal-container" tabindex="-1" role="dialog" '
     'aria-modal="true" aria-labelledby="modal-title">'
 )
-accessible = (
+inner_accessible = (
     '<div class="modal-container" tabindex="-1" role="dialog" '
     'aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-desc">'
 )
 
-if legacy in html:
-    html = html.replace(legacy, accessible, 1)
-elif labelled in html:
-    html = html.replace(labelled, accessible, 1)
-elif accessible not in html:
+if inner_accessible in html:
+    html = html.replace(inner_accessible, inner_plain, 1)
+elif inner_labelled in html:
+    html = html.replace(inner_labelled, inner_plain, 1)
+elif inner_plain not in html:
     raise SystemExit("Could not find the app modal container")
 
-required_html = (
-    'role="dialog"',
+outer_pattern = re.compile(r'<div id="app-modal" class="modal-overlay"[^>]*>')
+outer_match = outer_pattern.search(html)
+if not outer_match:
+    raise SystemExit("Could not find the app modal overlay")
+
+outer_accessible = (
+    '<div id="app-modal" class="modal-overlay" aria-hidden="true" role="dialog" '
+    'aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-desc">'
+)
+html = html[:outer_match.start()] + outer_accessible + html[outer_match.end():]
+
+if html.count('role="dialog"') != 1:
+    raise SystemExit("Expected exactly one dialog role in the app modal markup")
+for marker in (
     'aria-modal="true"',
     'aria-labelledby="modal-title"',
     'aria-describedby="modal-desc"',
     'id="modal-title"',
     'id="modal-desc"',
-)
-for marker in required_html:
+):
     if marker not in html:
         raise SystemExit(f"App modal is missing accessible dialog marker: {marker}")
-
-if html.count(accessible) != 1:
-    raise SystemExit("Expected exactly one accessible app modal container")
 
 html_path.write_text(html, encoding="utf-8")
 
@@ -51,18 +60,18 @@ runtime_attributes = (
     ("aria-describedby", "modal-desc"),
 )
 for attribute, value in runtime_attributes:
-    overlay = f"    modal.setAttribute('{attribute}', '{value}');"
     dialog = f"    dialog?.setAttribute('{attribute}', '{value}');"
-    if overlay in js:
-        js = js.replace(overlay, dialog, 1)
-    elif dialog not in js:
+    overlay = f"    modal.setAttribute('{attribute}', '{value}');"
+    if dialog in js:
+        js = js.replace(dialog, overlay, 1)
+    elif overlay not in js:
         raise SystemExit(f"Could not find runtime app dialog attribute: {attribute}")
 
-if "modal.setAttribute('role', 'dialog');" in js:
-    raise SystemExit("App modal overlay must not expose duplicate dialog semantics")
 for attribute, value in runtime_attributes:
-    marker = f"dialog?.setAttribute('{attribute}', '{value}');"
+    marker = f"modal.setAttribute('{attribute}', '{value}');"
     if marker not in js:
-        raise SystemExit(f"App modal container is missing runtime attribute: {attribute}")
+        raise SystemExit(f"App modal overlay is missing runtime attribute: {attribute}")
+if "dialog?.setAttribute('role', 'dialog');" in js:
+    raise SystemExit("App modal container must not expose duplicate dialog semantics")
 
 js_path.write_text(js, encoding="utf-8")


### PR DESCRIPTION
## Summary

- keep `.modal-overlay` as the single accessible dialog, matching the existing runtime behavior
- keep `.modal-container` as the focus target without a second dialog role
- add `aria-describedby` to the static dialog markup
- fail maintenance if duplicate dialog semantics return

## Why

PR #311 removed the duplicate runtime dialog but made the deterministic interaction maintenance non-idempotent because `maintain_tabs.py` expects the established overlay-based runtime form. This follow-up keeps one dialog while preserving the existing maintenance contract.

Closes #310.