### PR TITLE
Keep local validation documentation aligned with CI

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -83,6 +83,8 @@ jobs:
         run: python scripts/check_llms_profile.py
       - name: Validate security contact
         run: python scripts/check_security_contact.py
+      - name: Validate documented local checks
+        run: python scripts/check_validation_docs.py
       - name: Validate full interaction maintenance
         run: |
           python scripts/run_deterministic_maintenance.py

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ python3.14 scripts/check_sidebar_role_derivation.py
 python3.14 scripts/check_social_profile_derivation.py
 python3.14 scripts/check_llms_profile.py
 python3.14 scripts/check_year_filter_coverage.py
+python3.14 scripts/check_validation_docs.py
 git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md llms.txt SECURITY.md .well-known/security.txt
 python3.14 scripts/maintain_static_fallbacks.py
 git diff --exit-code -- index.html sitemap.xml

--- a/scripts/check_validation_docs.py
+++ b/scripts/check_validation_docs.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+README = Path("README.md")
+WORKFLOW = Path(".github/workflows/static.yml")
+CHECK_RE = re.compile(r"\b(?:python(?:3(?:\.14)?)?)\s+(scripts/check_[A-Za-z0-9_]+\.py)\b")
+
+
+def read_local_validation_block(text: str) -> str:
+    section = re.search(r"^## Local validation\s*$([\s\S]*?)(?=^##\s|\Z)", text, re.MULTILINE)
+    if not section:
+        raise SystemExit("README.md: missing '## Local validation' section")
+
+    code_block = re.search(r"```bash\s*\n([\s\S]*?)\n```", section.group(1))
+    if not code_block:
+        raise SystemExit("README.md: missing primary bash block in local validation section")
+    return code_block.group(1)
+
+
+def check_scripts(text: str) -> set[str]:
+    return set(CHECK_RE.findall(text))
+
+
+readme_text = README.read_text(encoding="utf-8")
+workflow_text = WORKFLOW.read_text(encoding="utf-8")
+
+readme_checks = check_scripts(read_local_validation_block(readme_text))
+workflow_checks = check_scripts(workflow_text)
+
+only_readme = sorted(readme_checks - workflow_checks)
+only_workflow = sorted(workflow_checks - readme_checks)
+
+if only_readme or only_workflow:
+    if only_readme:
+        print("Validation checks documented locally but not run by static.yml:")
+        for path in only_readme:
+            print(f"  - {path}")
+    if only_workflow:
+        print("Validation checks run by static.yml but missing from README local validation:")
+        for path in only_workflow:
+            print(f"  - {path}")
+    raise SystemExit(1)
+
+if not workflow_checks:
+    raise SystemExit("No scripts/check_*.py validations found in static.yml")
+
+print(f"Validation documentation aligned: {len(workflow_checks)} deterministic checks")


### PR DESCRIPTION
Closes #314.

## What changed
- add `scripts/check_validation_docs.py` to compare deterministic `scripts/check_*.py` checks in the README local-validation block with `.github/workflows/static.yml`
- run the alignment check in post-optimization validation
- include the check in the documented local command sequence

## Why
The README and CI previously maintained the validation list independently. That drift already caused local validation to miss checks that CI ran. This turns the documentation/CI contract into an enforced invariant rather than a manual convention.

## Scope
No portfolio content, styling, or user-facing behavior changes. Network-dependent external-link validation remains separate.