### PR TITLE
Validate maintenance Python syntax in CI

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -49,6 +49,8 @@ jobs:
               exit 1
             fi
           done
+      - name: Validate maintenance script syntax
+        run: python -m py_compile scripts/*.py
       - name: Validate JavaScript syntax
         run: node --check main.js
       - name: Validate site integrity

--- a/scripts/check_validation_docs.py
+++ b/scripts/check_validation_docs.py
@@ -7,6 +7,7 @@ README = Path("README.md")
 WORKFLOW = Path(".github/workflows/static.yml")
 CHECK_RE = re.compile(r"\b(?:python(?:3(?:\.14)?)?)\s+(scripts/check_[A-Za-z0-9_]+\.py)\b")
 REQUIRED_SHARED_STAGES = {
+    "Python syntax validation": "-m py_compile scripts/*.py",
     "JavaScript syntax validation": "node --check main.js",
     "deterministic maintenance": "scripts/run_deterministic_maintenance.py",
     "maintenance idempotence diff": (


### PR DESCRIPTION
## Summary

- compile every checked-in Python maintenance script during post-optimization validation
- keep that syntax-validation stage aligned with the README local validation instructions
- prevent future drift through `check_validation_docs.py`

## Why

The README already requires `py_compile`, but CI did not. Individual checks exercise many scripts, not necessarily every helper or infrequently used maintenance path. This change makes syntax validity a repository-wide baseline rather than an incidental side effect of whichever scripts happen to run.

Closes #316.