### PR TITLE
Simplify header control maintenance

### DIFF
--- a/scripts/maintain_header_controls.py
+++ b/scripts/maintain_header_controls.py
@@ -101,9 +101,16 @@ language_button_action = (
     '<button class="header-btn" id="lang-toggle" type="button" '
     'aria-label="Switch to English / 英語に切り替え">'
 )
+language_button_localized = (
+    '<button class="header-btn" id="lang-toggle" type="button" '
+    'aria-label="英語に切り替え">'
+)
 if language_button in text:
     text = text.replace(language_button, language_button_accessible, 1)
-elif language_button_accessible not in text and language_button_action not in text:
+elif all(
+    marker not in text
+    for marker in (language_button_accessible, language_button_action, language_button_localized)
+):
     raise SystemExit('Could not find language toggle button')
 
 theme_button = (
@@ -118,9 +125,16 @@ theme_button_action = (
     '<button class="header-btn" id="theme-toggle" type="button" '
     'aria-label="Switch to light theme / ライトテーマに切り替え">'
 )
+theme_button_localized = (
+    '<button class="header-btn" id="theme-toggle" type="button" '
+    'aria-label="ライトテーマに切り替え">'
+)
 if theme_button in text:
     text = text.replace(theme_button, theme_button_accessible, 1)
-elif theme_button_accessible not in text and theme_button_action not in text:
+elif all(
+    marker not in text
+    for marker in (theme_button_accessible, theme_button_action, theme_button_localized)
+):
     raise SystemExit('Could not find theme toggle button')
 
 # The theme control already has an accessible name. Its moon/sun glyph is only

--- a/scripts/prepare_header_section_reordering.py
+++ b/scripts/prepare_header_section_reordering.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Prepare current markup for legacy header maintenance transforms.
 
-Stable deep-link IDs are restored later by maintain_tab_deep_links.py. The
-language/theme maintenance scripts also restore active-language action names
-after maintain_header_controls.py runs. This compatibility step keeps the
-legacy header transform independent from those newer generated states.
+Stable deep-link IDs are restored later by maintain_tab_deep_links.py. This
+compatibility step only removes generated section IDs so the legacy header
+transform can continue to locate sections by their historical structure.
 """
 
 from pathlib import Path
@@ -20,11 +19,6 @@ STATIC_SECTION_IDS = (
     "engineer-my-apps-and-services",
 )
 
-HEADER_CONTROL_COMPATIBILITY = {
-    'aria-label="英語に切り替え"': 'aria-label="Switch to English / 英語に切り替え"',
-    'aria-label="ライトテーマに切り替え"': 'aria-label="Switch to light theme / ライトテーマに切り替え"',
-}
-
 
 def main() -> None:
     html = INDEX.read_text(encoding="utf-8")
@@ -33,14 +27,6 @@ def main() -> None:
         marker = f'<section class="section-card" id="{section_id}">'
         if marker in html:
             html = html.replace(marker, '<section class="section-card">', 1)
-
-    # maintain_header_controls.py predates the active-language action labels and
-    # recognizes its historical bilingual states. Normalize only for that
-    # maintenance stage; the dedicated language/theme transforms run later and
-    # restore the visitor-facing localized names before generated files settle.
-    for localized, legacy in HEADER_CONTROL_COMPATIBILITY.items():
-        if localized in html:
-            html = html.replace(localized, legacy, 1)
 
     INDEX.write_text(html, encoding="utf-8")
 


### PR DESCRIPTION
Closes #318.

## What changed
- Let `maintain_header_controls.py` accept the current localized language and theme action labels directly.
- Remove the temporary language/theme label rewrites from `prepare_header_section_reordering.py`.
- Keep the section-ID compatibility work unchanged.

## Why
The deterministic maintenance flow no longer needs to convert two correct accessibility labels into legacy bilingual strings and then restore them later. This removes an order-sensitive dependency without changing visitor-facing markup.

## Review focus
- Final `index.html` should remain unchanged after deterministic maintenance.
- Language/theme accessible names should remain localized to the active language.
- Section reordering and stable-ID maintenance should behave exactly as before.