### PR TITLE
Remove fixed CV header line positions

### DIFF
--- a/scripts/check_sidebar_role_derivation.py
+++ b/scripts/check_sidebar_role_derivation.py
@@ -3,13 +3,15 @@
 
 from pathlib import Path
 
-from maintain_profile_metadata import build_sidebar_roles
+from maintain_profile_metadata import build_sidebar_roles, read_cv_header_profile
 
 
 def main() -> None:
     synthetic_cv = """TAIGO SAKAI
 Portfolio: https://example.com
 Email: test@example.com
+Publication name: T. Sakai
+ORCID: https://orcid.org/0000-0000-0000-0000
 Ph.D. Student | Visiting Researcher | Computer Vision Researcher
 Meijo University, Japan
 """
@@ -19,6 +21,20 @@ Meijo University, Japan
     if japanese != "博士後期課程 · Visiting Researcher":
         raise SystemExit(f"Japanese sidebar role did not localize changed CV roles: {japanese!r}")
 
+    roles, affiliation = read_cv_header_profile(synthetic_cv)
+    if roles != ["Ph.D. Student", "Visiting Researcher", "Computer Vision Researcher"]:
+        raise SystemExit(f"CV role header was not found after extra preamble fields: {roles!r}")
+    if affiliation != "Meijo University":
+        raise SystemExit(f"CV affiliation was not found after the role header: {affiliation!r}")
+
+    ambiguous_cv = synthetic_cv + "\nResearcher | Engineer\nAnother University, Japan\n"
+    try:
+        read_cv_header_profile(ambiguous_cv)
+    except SystemExit:
+        pass
+    else:
+        raise SystemExit("Ambiguous CV role headers should be rejected")
+
     cv_text = Path("assets/cv.txt").read_text(encoding="utf-8")
     index_text = Path("index.html").read_text(encoding="utf-8")
     japanese, english = build_sidebar_roles(cv_text)
@@ -27,7 +43,7 @@ Meijo University, Japan
     if english not in index_text:
         raise SystemExit(f"Current English sidebar role is not CV-derived: {english!r}")
 
-    print("OK: sidebar roles derive from the CV role header and follow role changes")
+    print("OK: sidebar roles derive from the CV role header without fixed line positions")
 
 
 if __name__ == "__main__":

--- a/scripts/check_sidebar_role_derivation.py
+++ b/scripts/check_sidebar_role_derivation.py
@@ -27,7 +27,10 @@ Meijo University, Japan
     if affiliation != "Meijo University":
         raise SystemExit(f"CV affiliation was not found after the role header: {affiliation!r}")
 
-    ambiguous_cv = synthetic_cv + "\nResearcher | Engineer\nAnother University, Japan\n"
+    ambiguous_cv = synthetic_cv.replace(
+        "Ph.D. Student | Visiting Researcher | Computer Vision Researcher\n",
+        "Ph.D. Student | Visiting Researcher | Computer Vision Researcher\nResearcher | Engineer\n",
+    )
     try:
         read_cv_header_profile(ambiguous_cv)
     except SystemExit:

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -27,12 +27,9 @@ def read_cv_field(cv_text: str, label: str) -> str:
 
 
 def read_cv_header_profile(cv_text: str) -> tuple[list[str], str]:
-    lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
-    role_indexes = [
-        index
-        for index, line in enumerate(lines[:-1])
-        if " | " in line and not re.match(r"^[A-Za-z][A-Za-z ]*:\s*", line)
-    ]
+    preamble = cv_text.split("\n\n", 1)[0]
+    lines = [line.strip() for line in preamble.splitlines() if line.strip()]
+    role_indexes = [index for index, line in enumerate(lines[:-1]) if " | " in line]
     if len(role_indexes) != 1:
         raise SystemExit("assets/cv.txt must contain exactly one role header followed by affiliation")
 

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -28,12 +28,18 @@ def read_cv_field(cv_text: str, label: str) -> str:
 
 def read_cv_header_profile(cv_text: str) -> tuple[list[str], str]:
     lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
-    if len(lines) < 5 or " | " not in lines[3]:
-        raise SystemExit("assets/cv.txt is missing the expected role and affiliation header")
+    role_indexes = [
+        index
+        for index, line in enumerate(lines[:-1])
+        if " | " in line and not re.match(r"^[A-Za-z][A-Za-z ]*:\s*", line)
+    ]
+    if len(role_indexes) != 1:
+        raise SystemExit("assets/cv.txt must contain exactly one role header followed by affiliation")
 
-    roles = [role.strip() for role in lines[3].split("|") if role.strip()]
-    affiliation = lines[4].split(",", 1)[0].strip()
-    if not roles or not affiliation:
+    role_index = role_indexes[0]
+    roles = [role.strip() for role in lines[role_index].split("|") if role.strip()]
+    affiliation = lines[role_index + 1].split(",", 1)[0].strip()
+    if len(roles) < 2 or not affiliation or ":" in affiliation:
         raise SystemExit("assets/cv.txt has an incomplete role or affiliation header")
     return roles, affiliation
 


### PR DESCRIPTION
## Summary

- identify the pipe-delimited role header by content instead of fixed non-empty line numbers
- derive affiliation from the following non-empty line
- reject ambiguous or incomplete role headers
- extend the sidebar-role regression check with extra machine-readable preamble fields and an ambiguity case

## Why

Closes #324. Adding an unrelated machine-readable CV field before the role header should not silently change portfolio role or affiliation metadata.

## Impact

No visible portfolio content is intentionally changed. This makes profile maintenance less sensitive to incidental `assets/cv.txt` line placement.