### PR TITLE
Serve cached app thumbnails from the portfolio origin

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -47,6 +47,8 @@ jobs:
               'if local_path.is_file():',
               'return local_web_path',
               'if filename not in expected_files:',
+              'local_img.startswith("assets/thumbnails/")',
+              'sync_index_app_thumbnails(data["apps"])',
           ]
           missing = [snippet for snippet in required if snippet not in text]
           if missing:

--- a/scripts/sync_readme_assets.py
+++ b/scripts/sync_readme_assets.py
@@ -17,6 +17,7 @@ README_URL = "https://raw.githubusercontent.com/sakai1250/sakai1250/main/Readme.
 ASSETS_DIR = ROOT / "assets"
 THUMB_DIR = ASSETS_DIR / "thumbnails"
 DATA_FILE = ASSETS_DIR / "data.json"
+INDEX_FILE = ROOT / "index.html"
 
 
 def extract_images(content: str, header_pattern: str) -> list[dict[str, str]]:
@@ -71,6 +72,45 @@ def sync_app_thumbnail(full_repo: str, img_src: str) -> str:
             print(f"Using cached thumbnail for {full_repo}: {local_web_path}")
             return local_web_path
         return img_src
+
+
+def sync_index_app_thumbnails(apps: dict[str, dict]) -> None:
+    """Use cached app thumbnails in static cards when an exact repo match exists."""
+    text = INDEX_FILE.read_text(encoding="utf-8")
+    original = text
+
+    for full_repo, app in apps.items():
+        local_img = str(app.get("img", "")).strip()
+        if not local_img.startswith("assets/thumbnails/"):
+            continue
+
+        repo_url = f"https://github.com/{full_repo}"
+        repo_pos = text.find(repo_url)
+        if repo_pos < 0:
+            continue
+
+        card_start = text.rfind('<div class="app-card"', 0, repo_pos)
+        img_start = text.find("<img", card_start, repo_pos) if card_start >= 0 else -1
+        img_end = text.find(">", img_start, repo_pos) if img_start >= 0 else -1
+        if img_start < 0 or img_end < 0:
+            continue
+
+        img_tag = text[img_start : img_end + 1]
+        if 'class="app-thumb"' not in img_tag:
+            continue
+
+        updated_tag, count = re.subn(
+            r'\bsrc=(["\']).*?\1',
+            f'src="{local_img}"',
+            img_tag,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+        if count:
+            text = text[:img_start] + updated_tag + text[img_end + 1 :]
+
+    if text != original:
+        INDEX_FILE.write_text(text, encoding="utf-8")
 
 
 def main() -> None:
@@ -139,6 +179,7 @@ def main() -> None:
         json.dumps(data, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
+    sync_index_app_thumbnails(data["apps"])
 
 
 if __name__ == "__main__":

--- a/scripts/sync_readme_assets.py
+++ b/scripts/sync_readme_assets.py
@@ -78,6 +78,8 @@ def sync_index_app_thumbnails(apps: dict[str, dict]) -> None:
     """Use cached app thumbnails in static cards when an exact repo match exists."""
     text = INDEX_FILE.read_text(encoding="utf-8")
     original = text
+    apps_section_start = text.find('id="engineer-my-apps-and-services"')
+    search_start = apps_section_start if apps_section_start >= 0 else 0
 
     for full_repo, app in apps.items():
         local_img = str(app.get("img", "")).strip()
@@ -85,11 +87,11 @@ def sync_index_app_thumbnails(apps: dict[str, dict]) -> None:
             continue
 
         repo_url = f"https://github.com/{full_repo}"
-        repo_pos = text.find(repo_url)
+        repo_pos = text.find(repo_url, search_start)
         if repo_pos < 0:
             continue
 
-        card_start = text.rfind('<div class="app-card"', 0, repo_pos)
+        card_start = text.rfind('<div class="app-card"', search_start, repo_pos)
         img_start = text.find("<img", card_start, repo_pos) if card_start >= 0 else -1
         img_end = text.find(">", img_start, repo_pos) if img_start >= 0 else -1
         if img_start < 0 or img_end < 0:


### PR DESCRIPTION
## Summary

Use the app thumbnails already cached under `assets/thumbnails/` in the static Apps & Services cards whenever `assets/data.json` has an exact repository mapping.

## Changes

- extend `sync_readme_assets.py` so cached thumbnail paths are also synchronized into matching static app cards in `index.html`
- leave cards without a local thumbnail unchanged
- keep existing decorative empty `alt` text
- extend the existing thumbnail-cache workflow guard so the local-card synchronization cannot disappear unnoticed

## Why

The portfolio already downloads and keeps these WebP files, but the rendered cards still depended on `github.com/user-attachments`. Serving the cached files from the same GitHub Pages origin reduces an unnecessary external dependency in a recruiter-facing section without changing the visual content.

Closes #326.