### PR TITLE
Remove remaining fixed CV role-line dependency

### DIFF
--- a/scripts/check_sidebar_role_derivation.py
+++ b/scripts/check_sidebar_role_derivation.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Verify that sidebar roles follow the CV header instead of fixed role text."""
+"""Verify that CV-derived roles and titles do not depend on fixed line positions."""
 
 from pathlib import Path
 
-from maintain_profile_metadata import build_sidebar_roles, read_cv_header_profile
+from maintain_profile_metadata import build_page_title, build_sidebar_roles, read_cv_header_profile
 
 
 def main() -> None:
@@ -27,6 +27,10 @@ Meijo University, Japan
     if affiliation != "Meijo University":
         raise SystemExit(f"CV affiliation was not found after the role header: {affiliation!r}")
 
+    expected_title = "Taigo Sakai | Ph.D. Student, Visiting Researcher & Computer Vision Researcher"
+    if build_page_title(synthetic_cv) != expected_title:
+        raise SystemExit("Page title did not follow the content-based CV role parser")
+
     ambiguous_cv = synthetic_cv.replace(
         "Ph.D. Student | Visiting Researcher | Computer Vision Researcher\n",
         "Ph.D. Student | Visiting Researcher | Computer Vision Researcher\nResearcher | Engineer\n",
@@ -46,7 +50,15 @@ Meijo University, Japan
     if english not in index_text:
         raise SystemExit(f"Current English sidebar role is not CV-derived: {english!r}")
 
-    print("OK: sidebar roles derive from the CV role header without fixed line positions")
+    header_source = Path("scripts/maintain_header_controls.py").read_text(encoding="utf-8")
+    if "from maintain_profile_metadata import build_page_title" not in header_source:
+        raise SystemExit("Header title maintenance does not reuse the shared CV page-title parser")
+    if "build_page_title(cv_text)" not in header_source:
+        raise SystemExit("Header title maintenance does not derive its title from the shared CV parser")
+    if "cv_lines[3]" in header_source:
+        raise SystemExit("Header title maintenance still depends on the fourth non-empty CV line")
+
+    print("OK: CV-derived roles and titles do not depend on fixed line positions")
 
 
 if __name__ == "__main__":

--- a/scripts/maintain_header_controls.py
+++ b/scripts/maintain_header_controls.py
@@ -4,6 +4,7 @@ import re
 
 import maintain_filter_accessibility
 from maintain_asset_versions import main as maintain_asset_versions
+from maintain_profile_metadata import build_page_title
 from maintain_social_profile import build_social_description
 
 
@@ -11,16 +12,9 @@ path = Path('index.html')
 text = path.read_text(encoding='utf-8')
 cv_text = Path('assets/cv.txt').read_text(encoding='utf-8')
 
-# Derive public titles from the CV role header so search results and shared links
-# cannot drift when the current academic or research role changes.
-cv_lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
-if len(cv_lines) < 5 or ' | ' not in cv_lines[3]:
-    raise SystemExit('assets/cv.txt is missing the expected role header')
-roles = [role.strip() for role in cv_lines[3].split('|') if role.strip()]
-if not roles:
-    raise SystemExit('assets/cv.txt has an empty role header')
-role_title = roles[0] if len(roles) == 1 else ', '.join(roles[:-1]) + ' & ' + roles[-1]
-page_title = html.escape(f'Taigo Sakai | {role_title}', quote=True)
+# Reuse the profile parser for public titles so every maintenance step interprets
+# the CV role header with the same content-based rules.
+page_title = html.escape(build_page_title(cv_text), quote=True)
 social_description = html.escape(build_social_description(cv_text), quote=True)
 
 def replace_title(pattern, replacement, label):


### PR DESCRIPTION
## Summary

Closes #328.

- Reuse `build_page_title()` from `maintain_profile_metadata.py` inside `maintain_header_controls.py`.
- Remove the duplicate assumption that the fourth non-empty CV line is the role header.
- Extend `check_sidebar_role_derivation.py` so extra machine-readable preamble fields remain supported and fixed-position parsing cannot silently return.

## Why this matters

- **Researcher:** adding ORCID or other profile metadata before the role line no longer risks breaking public research titles.
- **Recruiter:** document and social-card titles continue to reflect the current CV role reliably.
- **Engineer:** all title maintenance now uses the same content-based CV parser instead of two competing rules.

## Scope

No visible portfolio content or styling is intentionally changed.