### PR TITLE
Consolidate utility-control localization maintenance

### DIFF
--- a/scripts/maintain_header_controls.py
+++ b/scripts/maintain_header_controls.py
@@ -306,34 +306,6 @@ if app_thumbnail_alt in text:
 elif app_thumbnail_decorative not in text:
     raise SystemExit('Could not find app thumbnail accessibility markers')
 
-# Utility controls are localized later in the maintenance flow. Accept the
-# current localized form as already valid so correct HTML does not have to be
-# converted back to a legacy mixed-language label before this script runs.
-utility_labels = (
-    (
-        'aria-label="Back to top"',
-        'aria-label="Back to top / トップへ戻る"',
-        'aria-label="トップへ戻る" data-ja-aria-label="トップへ戻る" data-en-aria-label="Back to top"',
-    ),
-    (
-        'aria-label="目次"',
-        'aria-label="Table of contents / 目次"',
-        'aria-label="目次" data-ja-aria-label="目次" data-en-aria-label="Table of contents"',
-    ),
-    (
-        'aria-label="Close"',
-        'aria-label="Close / 閉じる"',
-        'aria-label="閉じる" data-ja-aria-label="閉じる" data-en-aria-label="Close"',
-    ),
-)
-for old_label, bilingual_label, localized_label in utility_labels:
-    if localized_label in text:
-        continue
-    if old_label in text:
-        text = text.replace(old_label, bilingual_label, 1)
-    elif bilingual_label not in text:
-        raise SystemExit(f'Could not find utility control label: {old_label}')
-
 # Name the top-level tab list by what it actually switches. "Primary sections"
 # is vague when announced without visual context; this identifies the two views
 # directly for screen-reader users. The localized form is already the final


### PR DESCRIPTION
## Summary
- remove Back to top, Table of contents, and modal Close label maintenance from `maintain_header_controls.py`
- leave those accessible names under the dedicated `maintain_utility_control_localization.py` step
- keep the current Japanese/English labels unchanged

## Why
The same utility controls were maintained twice in sequence. Keeping one owner reduces order sensitivity and means future accessibility wording changes do not need synchronized edits in an unrelated header maintenance script.

## Validation
The diff is intentionally limited to deleting the duplicate block. Existing utility-control localization checks remain responsible for behavior-level coverage.

Closes #330.