### PR TITLE
Remove duplicate social title maintenance

### DIFF
--- a/scripts/check_sidebar_role_derivation.py
+++ b/scripts/check_sidebar_role_derivation.py
@@ -50,13 +50,22 @@ Meijo University, Japan
     if english not in index_text:
         raise SystemExit(f"Current English sidebar role is not CV-derived: {english!r}")
 
+    # Public title metadata belongs to maintain_profile_metadata.py. Header
+    # maintenance must not grow a second CV-title parser or rewrite the same
+    # title tags again.
     header_source = Path("scripts/maintain_header_controls.py").read_text(encoding="utf-8")
-    if "from maintain_profile_metadata import build_page_title" not in header_source:
-        raise SystemExit("Header title maintenance does not reuse the shared CV page-title parser")
-    if "build_page_title(cv_text)" not in header_source:
-        raise SystemExit("Header title maintenance does not derive its title from the shared CV parser")
-    if "cv_lines[3]" in header_source:
-        raise SystemExit("Header title maintenance still depends on the fourth non-empty CV line")
+    duplicate_title_markers = (
+        "build_page_title",
+        "<title>",
+        "og:title",
+        "twitter:title",
+    )
+    duplicate_markers = [marker for marker in duplicate_title_markers if marker in header_source]
+    if duplicate_markers:
+        raise SystemExit(
+            "Header maintenance duplicates profile title ownership: "
+            + ", ".join(duplicate_markers)
+        )
 
     print("OK: CV-derived roles and titles do not depend on fixed line positions")
 

--- a/scripts/maintain_header_controls.py
+++ b/scripts/maintain_header_controls.py
@@ -1,56 +1,12 @@
 from pathlib import Path
-import html
 import re
 
 import maintain_filter_accessibility
 from maintain_asset_versions import main as maintain_asset_versions
-from maintain_profile_metadata import build_page_title
-from maintain_social_profile import build_social_description
 
 
 path = Path('index.html')
 text = path.read_text(encoding='utf-8')
-cv_text = Path('assets/cv.txt').read_text(encoding='utf-8')
-
-# Reuse the profile parser for public titles so every maintenance step interprets
-# the CV role header with the same content-based rules.
-page_title = html.escape(build_page_title(cv_text), quote=True)
-social_description = html.escape(build_social_description(cv_text), quote=True)
-
-def replace_title(pattern, replacement, label):
-    global text
-    text, count = re.subn(pattern, replacement, text, count=1)
-    if count != 1:
-        raise SystemExit(f'Could not find expected {label}')
-
-replace_title(r'<title>Taigo Sakai \| [^<]+</title>', f'<title>{page_title}</title>', 'document title')
-replace_title(
-    r'<meta property="og:title" content="Taigo Sakai \| [^"]+">',
-    f'<meta property="og:title" content="{page_title}">',
-    'Open Graph title',
-)
-
-# Keep social-card metadata as complete as the Open Graph metadata. This makes
-# shared portfolio links identify the person and research field without relying
-# on platform-specific fallback behavior.
-twitter_creator = '<meta name="twitter:creator" content="@ikaitaig">'
-twitter_metadata = (
-    '<meta name="twitter:creator" content="@ikaitaig">\n'
-    f'  <meta name="twitter:title" content="{page_title}">\n'
-    f'  <meta name="twitter:description" content="{social_description}">\n'
-    '  <meta name="twitter:image" content="https://github.com/sakai1250.png">\n'
-    '  <meta name="twitter:image:alt" content="Portrait of Taigo Sakai">'
-)
-if '<meta name="twitter:title"' not in text:
-    if twitter_creator not in text:
-        raise SystemExit('Could not find Twitter creator metadata')
-    text = text.replace(twitter_creator, twitter_metadata, 1)
-else:
-    replace_title(
-        r'<meta name="twitter:title" content="Taigo Sakai \| [^"]+">',
-        f'<meta name="twitter:title" content="{page_title}">',
-        'Twitter title',
-    )
 
 og_image = '<meta property="og:image" content="https://github.com/sakai1250.png">'
 og_image_with_alt = (


### PR DESCRIPTION
## Summary

- keep document / Open Graph / Twitter title ownership in `maintain_profile_metadata.py`
- remove the second title rewrite from `maintain_header_controls.py`
- remove the unreachable Twitter metadata creation branch from header maintenance
- preserve existing social-image locality and Open Graph image-alt maintenance

## Why

The deterministic maintenance runner executes profile metadata maintenance first, so header maintenance was rewriting metadata that had already been synchronized from `assets/cv.txt`. Its fallback for creating a missing `twitter:title` was also unreachable in that flow because the profile step requires that tag first.

This reduces duplicate ownership without changing generated portfolio content.

Fixes #338