### PR TITLE
Reuse CV parser in llms profile check

### DIFF
--- a/scripts/check_llms_profile.py
+++ b/scripts/check_llms_profile.py
@@ -3,6 +3,8 @@ import json
 import re
 from pathlib import Path
 
+from maintain_profile_metadata import read_cv_header_profile
+
 
 def require(text, needle, source):
     if needle not in text:
@@ -35,18 +37,6 @@ def read_cv_field(cv_text, label):
     if not match:
         raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
     return match.group(1)
-
-
-def read_cv_header_profile(cv_text):
-    lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
-    if len(lines) < 5 or " | " not in lines[3]:
-        raise SystemExit("assets/cv.txt is missing the expected role and affiliation header")
-
-    roles = [role.strip() for role in lines[3].split("|") if role.strip()]
-    affiliation = lines[4].split(",", 1)[0].strip()
-    if not roles or not affiliation:
-        raise SystemExit("assets/cv.txt has an incomplete role or affiliation header")
-    return roles, affiliation
 
 
 def main():

--- a/scripts/check_social_profile_derivation.py
+++ b/scripts/check_social_profile_derivation.py
@@ -64,17 +64,21 @@ Future University, Tokyo, Japan
     if expected_og_tag not in index_text:
         raise SystemExit("Current Open Graph description does not match assets/cv.txt")
 
+    # Social description ownership belongs to the dedicated social-profile
+    # transform. Header maintenance should not duplicate that CV-derived logic.
     header_source = Path("scripts/maintain_header_controls.py").read_text(encoding="utf-8")
-    if "from maintain_social_profile import build_social_description" not in header_source:
-        raise SystemExit("Header maintenance does not reuse the CV-derived social description helper")
-    if "build_social_description(cv_text)" not in header_source:
-        raise SystemExit("Header maintenance does not derive social description from the current CV")
+    if "build_social_description" in header_source:
+        raise SystemExit("Header maintenance duplicates social-description ownership")
+
+    social_source = Path("scripts/maintain_social_profile.py").read_text(encoding="utf-8")
+    if "build_social_description(cv_text)" not in social_source:
+        raise SystemExit("Social-profile maintenance does not derive description from the current CV")
     stale_social_literal = (
         "Ph.D. Student and Special Assistant at Meijo University researching "
         "Computer Vision, Continual Learning, and Multi-View Tracking."
     )
-    if stale_social_literal in header_source:
-        raise SystemExit("Header maintenance still contains a hard-coded current-profile description")
+    if stale_social_literal in social_source or stale_social_literal in header_source:
+        raise SystemExit("Maintenance still contains a hard-coded current-profile description")
 
     profile_source = Path("scripts/maintain_profile_metadata.py").read_text(encoding="utf-8")
     if "from maintain_social_profile import build_search_description" not in profile_source:


### PR DESCRIPTION
## Summary

- reuse the shared `read_cv_header_profile` helper from `maintain_profile_metadata.py` in `check_llms_profile.py`
- remove the fixed 4th/5th non-empty-line assumption from that check
- align `check_social_profile_derivation.py` with the current ownership split: social description logic belongs to `maintain_social_profile.py`, not `maintain_header_controls.py`

This addresses the `check_llms_profile.py` half of #340. `check_structured_profile.py` still has the same duplicate CV parser and remains tracked by that issue.

## Why

A harmless machine-readable field added before the CV role header should not create a false CI failure after the maintained site has already parsed the CV correctly. The regression check also should not require duplicate social-description logic that was intentionally removed from header maintenance.

## Validation

GitHub Actions on this branch exercise the structured-profile, site-integrity, and interaction-maintenance checks before merge.