### PR TITLE
Reuse CV parser in structured profile check

### DIFF
--- a/scripts/check_structured_profile.py
+++ b/scripts/check_structured_profile.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import json
 import re
 
+from maintain_profile_metadata import read_cv_header_profile
+
 
 PROFILE_FIELDS = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")
 RESEARCH_FOCUS = "Computer Vision, Continual Learning, and Multi-View Tracking"
@@ -69,18 +71,6 @@ def read_cv_field(cv_text, label):
     if not match:
         raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
     return match.group(1)
-
-
-def read_cv_header_profile(cv_text):
-    lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
-    if len(lines) < 5 or " | " not in lines[3]:
-        raise SystemExit("assets/cv.txt is missing the expected role and affiliation header")
-
-    roles = [role.strip() for role in lines[3].split("|") if role.strip()]
-    affiliation = lines[4].split(",", 1)[0].strip()
-    if not roles or not affiliation:
-        raise SystemExit("assets/cv.txt has an incomplete role or affiliation header")
-    return roles, affiliation
 
 
 def main():


### PR DESCRIPTION
Closes #340.

## What changed
- Reuse `maintain_profile_metadata.read_cv_header_profile` in `check_structured_profile.py`.
- Remove the remaining fixed 4th/5th non-empty-line parser copy.

## Why
The generated profile metadata and its validator should interpret the CV header with the same rule. Adding an ORCID or another machine-readable preamble field should not make the structured-profile check fail while the maintained site remains correct.

## Review scope
One validation script only: +2 / -12 lines. No visible site output changes.