### PR TITLE
Harden social profile CV header parsing

### DIFF
--- a/scripts/check_social_profile_derivation.py
+++ b/scripts/check_social_profile_derivation.py
@@ -11,6 +11,7 @@ def main() -> None:
     synthetic_cv = """TAIGO SAKAI
 Japanese name: 坂井 泰吾
 Publication name: T. Sakai
+ORCID: https://orcid.org/0000-0000-0000-0000
 Ph.D. Student | Visiting Researcher | Computer Vision Researcher
 Future University, Tokyo, Japan
 """

--- a/scripts/maintain_social_profile.py
+++ b/scripts/maintain_social_profile.py
@@ -19,13 +19,16 @@ AFFILIATION_LABELS_JA = {
 
 
 def read_cv_social_profile(cv_text: str) -> tuple[list[str], str]:
-    lines = [line.strip() for line in cv_text.splitlines() if line.strip()]
-    if len(lines) < 5 or " | " not in lines[3]:
-        raise SystemExit("assets/cv.txt is missing the expected role and affiliation header")
+    preamble = cv_text.split("\n\n", 1)[0]
+    lines = [line.strip() for line in preamble.splitlines() if line.strip()]
+    role_indexes = [index for index, line in enumerate(lines[:-1]) if " | " in line]
+    if len(role_indexes) != 1:
+        raise SystemExit("assets/cv.txt must contain exactly one role header followed by affiliation")
 
-    roles = [role.strip() for role in lines[3].split("|") if role.strip()]
-    affiliation = lines[4].split(",", 1)[0].strip()
-    if not roles or not affiliation:
+    role_index = role_indexes[0]
+    roles = [role.strip() for role in lines[role_index].split("|") if role.strip()]
+    affiliation = lines[role_index + 1].split(",", 1)[0].strip()
+    if not roles or not affiliation or ":" in affiliation:
         raise SystemExit("assets/cv.txt has an incomplete role or affiliation header")
     return roles, affiliation
 


### PR DESCRIPTION
Closes #343.

## What changed

- Parse the CV preamble for the unique role header instead of assuming roles are the fourth non-empty line.
- Read affiliation from the line immediately following that role header.
- Reject malformed headers whose supposed affiliation is another machine-readable `Label:` field.
- Extend the social-profile derivation regression check with an ORCID line before the role header.

## Why

The rest of the profile maintenance has moved away from fixed CV line numbers. Social/search metadata generation was the remaining generation path that could break when a legitimate researcher identifier or other header field was inserted before the roles.

The current visible metadata is unchanged; this only removes an unnecessary ordering constraint in `assets/cv.txt`.