### PR TITLE
Reuse CV field parser in profile checks

### DIFF
--- a/scripts/check_llms_profile.py
+++ b/scripts/check_llms_profile.py
@@ -3,7 +3,7 @@ import json
 import re
 from pathlib import Path
 
-from maintain_profile_metadata import read_cv_header_profile
+from maintain_profile_metadata import read_cv_field, read_cv_header_profile
 
 
 def require(text, needle, source):
@@ -30,13 +30,6 @@ def read_person_json_ld(index_text):
         if data.get("@type") == "Person":
             return data
     raise SystemExit("index.html is missing Person JSON-LD")
-
-
-def read_cv_field(cv_text, label):
-    match = re.search(rf"^{re.escape(label)}:\s*(\S+)\s*$", cv_text, flags=re.MULTILINE)
-    if not match:
-        raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
-    return match.group(1)
 
 
 def main():

--- a/scripts/check_structured_profile.py
+++ b/scripts/check_structured_profile.py
@@ -2,9 +2,8 @@
 from html.parser import HTMLParser
 from pathlib import Path
 import json
-import re
 
-from maintain_profile_metadata import read_cv_header_profile
+from maintain_profile_metadata import read_cv_field, read_cv_header_profile
 
 
 PROFILE_FIELDS = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")
@@ -64,13 +63,6 @@ def single_value(values, label):
     if not value:
         raise SystemExit(f"{label} must not be empty")
     return value
-
-
-def read_cv_field(cv_text, label):
-    match = re.search(rf"^{re.escape(label)}:\s*(\S+)\s*$", cv_text, flags=re.MULTILINE)
-    if not match:
-        raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
-    return match.group(1)
 
 
 def main():


### PR DESCRIPTION
## Summary
- reuse `maintain_profile_metadata.read_cv_field` in the llms profile check
- reuse the same helper in the structured profile check
- remove the two copied regular-expression parsers

## Why
The generated profile and its validation should interpret machine-readable CV fields with the same rule. Keeping separate copies means a future format change can make the maintenance script and CI disagree even when the public profile is correct.

## User impact
No visible content changes. This reduces false failures and stale assumptions when contact or professional-profile fields in `assets/cv.txt` evolve.

## Validation
The diff only removes duplicated parsing logic and imports the existing source-of-truth helper. GitHub Actions should verify the current CV, JSON-LD, llms.txt, recovery links, and social metadata remain aligned.