### PR TITLE
Reuse shared CV field parser for contact paths

### DIFF
--- a/scripts/check_security_contact.py
+++ b/scripts/check_security_contact.py
@@ -2,7 +2,8 @@
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from urllib.parse import urlsplit
-import re
+
+from maintain_profile_metadata import read_cv_field
 
 
 def main() -> None:
@@ -36,10 +37,7 @@ def main() -> None:
         raise SystemExit('Contact must include a mailto: or https:// URI')
 
     cv_text = Path('assets/cv.txt').read_text(encoding='utf-8')
-    cv_email_match = re.search(r'^Email:\s*(\S+@\S+)\s*$', cv_text, flags=re.MULTILINE)
-    if not cv_email_match:
-        raise SystemExit('assets/cv.txt is missing a machine-readable Email field')
-    profile_email = cv_email_match.group(1)
+    profile_email = read_cv_field(cv_text, 'Email')
     expected_mailto = f'mailto:{profile_email}'
     if expected_mailto not in contacts:
         raise SystemExit(

--- a/scripts/maintain_contact_form.py
+++ b/scripts/maintain_contact_form.py
@@ -1,14 +1,13 @@
 import re
 from pathlib import Path
 
+from maintain_profile_metadata import read_cv_field
+
 path = Path('main.js')
 text = path.read_text(encoding='utf-8')
 
 cv_text = Path('assets/cv.txt').read_text(encoding='utf-8')
-email_match = re.search(r'^Email:\s*(\S+)\s*$', cv_text, re.MULTILINE)
-if not email_match:
-    raise SystemExit('Could not find Email field in assets/cv.txt')
-contact_email = email_match.group(1)
+contact_email = read_cv_field(cv_text, 'Email')
 
 contact_replacement = r'''function initContactForm() {
     const f = document.getElementById('contact-form');


### PR DESCRIPTION
## Summary

- reuse the existing `read_cv_field()` helper in contact-form maintenance
- reuse the same helper in the security contact check
- remove two independent `Email:` regular expressions
- keep generated site content unchanged

## Why

`assets/cv.txt` is the source of truth for the public contact address. The contact fallback, security policy checks, and profile checks should interpret that field with the same parser so a future format change cannot silently split them.

## Validation

The diff is limited to parser reuse in two Python scripts. No generated HTML, JavaScript, styling, or public profile content is changed.

Closes #348