### PR TITLE
Decouple profile checks from metadata maintenance

### DIFF
--- a/scripts/check_llms_profile.py
+++ b/scripts/check_llms_profile.py
@@ -3,7 +3,7 @@ import json
 import re
 from pathlib import Path
 
-from maintain_profile_metadata import read_cv_field, read_cv_header_profile
+from cv_profile import read_cv_field, read_cv_header_profile
 
 
 def require(text, needle, source):

--- a/scripts/check_security_contact.py
+++ b/scripts/check_security_contact.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from urllib.parse import urlsplit
 
-from maintain_profile_metadata import read_cv_field
+from cv_profile import read_cv_field
 
 
 def main() -> None:

--- a/scripts/check_structured_profile.py
+++ b/scripts/check_structured_profile.py
@@ -3,7 +3,7 @@ from html.parser import HTMLParser
 from pathlib import Path
 import json
 
-from maintain_profile_metadata import read_cv_field, read_cv_header_profile
+from cv_profile import read_cv_field, read_cv_header_profile
 
 
 PROFILE_FIELDS = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")

--- a/scripts/cv_profile.py
+++ b/scripts/cv_profile.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 """Parse machine-readable profile fields from assets/cv.txt."""
 
+import re
+
+
+def read_cv_field(cv_text: str, label: str) -> str:
+    match = re.search(rf"^{re.escape(label)}:\s*(\S+)\s*$", cv_text, flags=re.MULTILINE)
+    if not match:
+        raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
+    return match.group(1)
+
 
 def read_cv_header_profile(cv_text: str) -> tuple[list[str], str]:
     preamble = cv_text.split("\n\n", 1)[0]

--- a/scripts/maintain_contact_form.py
+++ b/scripts/maintain_contact_form.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-from maintain_profile_metadata import read_cv_field
+from cv_profile import read_cv_field
 
 path = Path('main.js')
 text = path.read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary

- add `read_cv_field()` to the dependency-light `cv_profile.py` parser module
- make profile checks import both CV parsers directly from `cv_profile`
- make contact-form maintenance and the security contact check import the field parser directly
- leave generated portfolio content unchanged

## Why

These consumers only need to read machine-readable CV data. Importing those helpers through `maintain_profile_metadata.py` couples validation and contact paths to a large script whose responsibility is rewriting page metadata.

This is the first step of #350. The legacy helper inside `maintain_profile_metadata.py` remains for compatibility and will be removed separately once its internal use is migrated safely.

## Review focus

- parser behavior is identical to the existing `read_cv_field()` implementation
- no public links, copy, metadata values, or accessibility behavior should change
- existing profile, security, interaction, and site-integrity checks should continue to pass