### PR TITLE
Finish centralizing CV field parsing

### DIFF
--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import html
 import re
 
-from cv_profile import read_cv_header_profile
+from cv_profile import read_cv_field, read_cv_header_profile
 from maintain_social_profile import build_search_description
 
 
@@ -18,13 +18,6 @@ SECURITY_CONTACT_PATH = Path(".well-known/security.txt")
 MAIN_JS_PATH = Path("main.js")
 CV_PATH = Path("assets/cv.txt")
 PROFILE_FIELDS = ("GitHub", "Qiita", "LinkedIn", "Google Scholar")
-
-
-def read_cv_field(cv_text: str, label: str) -> str:
-    match = re.search(rf"^{re.escape(label)}:\s*(\S+)\s*$", cv_text, flags=re.MULTILINE)
-    if not match:
-        raise SystemExit(f"assets/cv.txt is missing a machine-readable {label} field")
-    return match.group(1)
 
 
 def build_sidebar_roles(cv_text: str) -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- import `read_cv_field()` from `scripts/cv_profile.py` in metadata maintenance
- remove the duplicate local parser from `maintain_profile_metadata.py`
- keep generated public content unchanged

## Why
This completes #350 by making the dedicated CV parser module the single source of truth for machine-readable CV fields. It reduces coupling and prevents parser behavior from drifting between metadata generation and validation/contact paths.

## Validation
The diff is limited to one maintenance script and removes only the duplicate helper. Existing profile, interaction, security-contact, and site-integrity workflows should cover behavior before merge.

Closes #350