### PR TITLE
Separate profile description builders from metadata writes

### DIFF
--- a/scripts/maintain_social_profile.py
+++ b/scripts/maintain_social_profile.py
@@ -7,7 +7,7 @@ import html
 import re
 from pathlib import Path
 
-from profile_descriptions import build_social_description
+from profile_descriptions import build_search_description, build_social_description
 
 
 def replace_meta(text: str, pattern: re.Pattern[str], replacement: str, label: str) -> str:

--- a/scripts/maintain_social_profile.py
+++ b/scripts/maintain_social_profile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Provide profile description builders and synchronize Twitter metadata."""
+"""Synchronize Twitter profile metadata with the CV-derived description."""
 
 from __future__ import annotations
 
@@ -7,36 +7,7 @@ import html
 import re
 from pathlib import Path
 
-from cv_profile import read_cv_header_profile
-
-
-RESEARCH_FOCUS = "Computer Vision, Continual Learning, and Multi-View Tracking"
-SEARCH_RESEARCH_FOCUS = "Computer Vision、Continual Learning、Multi-View Tracking"
-ROLE_LABELS_JA = {
-    "Ph.D. Student": "博士後期課程",
-}
-AFFILIATION_LABELS_JA = {
-    "Meijo University": "名城大学大学院",
-}
-
-
-def build_social_description(cv_text: str) -> str:
-    roles, affiliation = read_cv_header_profile(cv_text)
-    visible_roles = roles[:2]
-    role_phrase = " and ".join(visible_roles)
-    return f"{role_phrase} at {affiliation} researching {RESEARCH_FOCUS}."
-
-
-def build_search_description(cv_text: str) -> str:
-    roles, affiliation = read_cv_header_profile(cv_text)
-    visible_roles = roles[:2]
-    localized_roles = [ROLE_LABELS_JA.get(role, role) for role in visible_roles]
-    localized_affiliation = AFFILIATION_LABELS_JA.get(affiliation, affiliation)
-    role_phrase = "・".join(localized_roles)
-    return (
-        f"{localized_affiliation} {role_phrase} 坂井泰吾のポートフォリオ。"
-        f"{SEARCH_RESEARCH_FOCUS}の研究とiOS/Web開発実績を紹介しています。"
-    )
+from profile_descriptions import build_social_description
 
 
 def replace_meta(text: str, pattern: re.Pattern[str], replacement: str, label: str) -> str:

--- a/scripts/profile_descriptions.py
+++ b/scripts/profile_descriptions.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Build CV-derived profile descriptions shared by metadata transforms."""
+
+from cv_profile import read_cv_header_profile
+
+
+RESEARCH_FOCUS = "Computer Vision, Continual Learning, and Multi-View Tracking"
+SEARCH_RESEARCH_FOCUS = "Computer Vision、Continual Learning、Multi-View Tracking"
+ROLE_LABELS_JA = {
+    "Ph.D. Student": "博士後期課程",
+}
+AFFILIATION_LABELS_JA = {
+    "Meijo University": "名城大学大学院",
+}
+
+
+def build_social_description(cv_text: str) -> str:
+    roles, affiliation = read_cv_header_profile(cv_text)
+    visible_roles = roles[:2]
+    role_phrase = " and ".join(visible_roles)
+    return f"{role_phrase} at {affiliation} researching {RESEARCH_FOCUS}."
+
+
+def build_search_description(cv_text: str) -> str:
+    roles, affiliation = read_cv_header_profile(cv_text)
+    visible_roles = roles[:2]
+    localized_roles = [ROLE_LABELS_JA.get(role, role) for role in visible_roles]
+    localized_affiliation = AFFILIATION_LABELS_JA.get(affiliation, affiliation)
+    role_phrase = "・".join(localized_roles)
+    return (
+        f"{localized_affiliation} {role_phrase} 坂井泰吾のポートフォリオ。"
+        f"{SEARCH_RESEARCH_FOCUS}の研究とiOS/Web開発実績を紹介しています。"
+    )


### PR DESCRIPTION
## What changed
- move CV-derived social/search description builders into `scripts/profile_descriptions.py`
- keep `maintain_social_profile.py` focused on updating Twitter metadata
- preserve the existing exported builder names so current checks and profile metadata maintenance keep working unchanged

## Why
The social maintenance script had become both a text-builder library and a file-writing transform. Separating the pure CV-derived description logic makes the ownership clearer and reduces the chance that future metadata maintenance changes introduce import-time or write-side coupling.

No public text, links, or page behavior are intentionally changed.