### PR TITLE
Finish profile description ownership separation

### DIFF
--- a/scripts/check_social_profile_derivation.py
+++ b/scripts/check_social_profile_derivation.py
@@ -4,7 +4,7 @@
 from html import escape
 from pathlib import Path
 
-from maintain_social_profile import build_search_description, build_social_description
+from profile_descriptions import build_search_description, build_social_description
 
 
 def main() -> None:
@@ -82,8 +82,8 @@ Future University, Tokyo, Japan
         raise SystemExit("Maintenance still contains a hard-coded current-profile description")
 
     profile_source = Path("scripts/maintain_profile_metadata.py").read_text(encoding="utf-8")
-    if "from maintain_social_profile import build_search_description" not in profile_source:
-        raise SystemExit("Profile maintenance does not reuse the CV-derived search description helper")
+    if "from profile_descriptions import build_search_description" not in profile_source:
+        raise SystemExit("Profile maintenance does not import the search description from its owner")
     if "build_search_description(cv_text)" not in profile_source:
         raise SystemExit("Profile maintenance does not derive search description from the current CV")
     stale_search_literal = (

--- a/scripts/maintain_profile_metadata.py
+++ b/scripts/maintain_profile_metadata.py
@@ -6,7 +6,7 @@ import html
 import re
 
 from cv_profile import read_cv_field, read_cv_header_profile
-from maintain_social_profile import build_search_description
+from profile_descriptions import build_search_description
 
 
 INDEX_PATH = Path("index.html")

--- a/scripts/maintain_social_profile.py
+++ b/scripts/maintain_social_profile.py
@@ -7,7 +7,7 @@ import html
 import re
 from pathlib import Path
 
-from profile_descriptions import build_search_description, build_social_description
+from profile_descriptions import build_social_description
 
 
 def replace_meta(text: str, pattern: re.Pattern[str], replacement: str, label: str) -> str:


### PR DESCRIPTION
## Summary
- import search description generation directly from `profile_descriptions.py`
- stop re-exporting the search builder through `maintain_social_profile.py`
- make the derivation check verify the actual helper owner

## Why
The previous extraction moved description builders into `profile_descriptions.py`, but profile metadata and its check still depended on `maintain_social_profile.py` as an accidental compatibility layer. This keeps read-only description generation independent from the Twitter metadata writer and makes ownership explicit.

## User impact
No visible portfolio copy or navigation changes. This is a maintainability and reliability cleanup that reduces hidden coupling between maintenance scripts.