### PR TITLE
Use one compile validation entrypoint

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -49,8 +49,8 @@ jobs:
               exit 1
             fi
           done
-      - name: Validate maintenance script syntax
-        run: python -m py_compile scripts/*.py
+      - name: Validate maintenance script syntax and registry
+        run: python scripts/run_deterministic_maintenance.py --compile-only
       - name: Validate JavaScript syntax
         run: node --check main.js
       - name: Validate site integrity

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Use Python 3.14 and Node 24 for maintenance and validation so local runs match G
 
 ```bash
 python3.14 -m pip install -r requirements-maintenance.txt
-python3.14 -m py_compile scripts/*.py
+python3.14 scripts/run_deterministic_maintenance.py --compile-only
 node --check main.js
 python3.14 scripts/run_deterministic_maintenance.py
 python3.14 scripts/check_app_repo_links.py

--- a/scripts/check_validation_docs.py
+++ b/scripts/check_validation_docs.py
@@ -7,7 +7,7 @@ README = Path("README.md")
 WORKFLOW = Path(".github/workflows/static.yml")
 CHECK_RE = re.compile(r"\b(?:python(?:3(?:\.14)?)?)\s+(scripts/check_[A-Za-z0-9_]+\.py)\b")
 REQUIRED_SHARED_STAGES = {
-    "Python syntax validation": "-m py_compile scripts/*.py",
+    "Python syntax and maintenance registry validation": "scripts/run_deterministic_maintenance.py --compile-only",
     "JavaScript syntax validation": "node --check main.js",
     "deterministic maintenance": "scripts/run_deterministic_maintenance.py",
     "maintenance idempotence diff": (


### PR DESCRIPTION
## Summary

Use `scripts/run_deterministic_maintenance.py --compile-only` as the shared Python validation entrypoint in both CI and the documented local workflow.

## Why

The compile-only path now compiles every Python file under `scripts/` and validates the explicit maintenance registry. `static.yml` and README still called `py_compile` directly, which duplicated part of that behavior and could drift from the central validation path.

## Changes

- replace direct `py_compile scripts/*.py` calls in CI and README with the shared compile-only command
- make the CI step name state that registry validation is included
- update `check_validation_docs.py` so future documentation/workflow drift is caught against the shared entrypoint

No portfolio content, styling, or public navigation changes.