### PR TITLE
Make thumbnail cache policy check reusable

### DIFF
--- a/.github/workflows/optimize-portfolio.yml
+++ b/.github/workflows/optimize-portfolio.yml
@@ -37,26 +37,7 @@ jobs:
         run: python scripts/sync_readme_assets.py
 
       - name: Guard thumbnail cache fallback policy
-        run: |
-          python <<'PY'
-          from pathlib import Path
-
-          text = Path('scripts/sync_readme_assets.py').read_text(encoding='utf-8')
-          required = [
-              'expected_files.add(filename)',
-              'if local_path.is_file():',
-              'return local_web_path',
-              'if filename not in expected_files:',
-              'local_img.startswith("assets/thumbnails/")',
-              'sync_index_app_thumbnails(data["apps"])',
-          ]
-          missing = [snippet for snippet in required if snippet not in text]
-          if missing:
-              raise SystemExit(f'Thumbnail cache fallback policy is incomplete: {missing}')
-          legacy_cleanup = 'if filename not in ' + 'generated_files:'
-          if legacy_cleanup in text:
-              raise SystemExit('Thumbnail cleanup still depends on current-run download success')
-          PY
+        run: python scripts/check_thumbnail_cache_policy.py
 
       - name: Keep deterministic portfolio maintenance aligned
         run: python scripts/run_deterministic_maintenance.py

--- a/scripts/check_thumbnail_cache_policy.py
+++ b/scripts/check_thumbnail_cache_policy.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Guard the thumbnail cache fallback policy used by asset maintenance."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SYNC_SCRIPT = ROOT / "scripts" / "sync_readme_assets.py"
+
+
+def main() -> None:
+    text = SYNC_SCRIPT.read_text(encoding="utf-8")
+    required = [
+        "expected_files.add(filename)",
+        "if local_path.is_file():",
+        "return local_web_path",
+        "if filename not in expected_files:",
+        'local_img.startswith("assets/thumbnails/")',
+        'sync_index_app_thumbnails(data["apps"])',
+    ]
+    missing = [snippet for snippet in required if snippet not in text]
+    if missing:
+        raise SystemExit(f"Thumbnail cache fallback policy is incomplete: {missing}")
+
+    legacy_cleanup = "if filename not in " + "generated_files:"
+    if legacy_cleanup in text:
+        raise SystemExit(
+            "Thumbnail cleanup still depends on current-run download success"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Move the thumbnail cache fallback regression check out of inline GitHub Actions YAML and into `scripts/check_thumbnail_cache_policy.py`.

## Why

- The current check can only be run from the workflow definition.
- A standalone Python check can be run locally and is automatically covered by the repository-wide Python compile validation.
- Keeping workflow YAML focused on orchestration makes the maintenance rule easier to inspect and change without editing embedded Python.

## Scope

No public portfolio content or behavior changes. The optimize workflow runs the same policy check through the reusable script.