### PR TITLE
Guard centralized Python runtime source

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -87,6 +87,8 @@ jobs:
         run: python scripts/check_llms_profile.py
       - name: Validate security contact
         run: python scripts/check_security_contact.py
+      - name: Validate Python runtime source
+        run: python scripts/check_python_runtime_alignment.py
       - name: Validate documented local checks
         run: python scripts/check_validation_docs.py
       - name: Validate full interaction maintenance

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ python3.14 scripts/check_sidebar_role_derivation.py
 python3.14 scripts/check_social_profile_derivation.py
 python3.14 scripts/check_llms_profile.py
 python3.14 scripts/check_year_filter_coverage.py
+python3.14 scripts/check_python_runtime_alignment.py
 python3.14 scripts/check_validation_docs.py
 git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md llms.txt SECURITY.md .well-known/security.txt
 python3.14 scripts/maintain_static_fallbacks.py

--- a/scripts/check_python_runtime_alignment.py
+++ b/scripts/check_python_runtime_alignment.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOW_DIR = Path(".github/workflows")
+PYTHON_VERSION = Path(".python-version")
+SETUP_PYTHON_RE = re.compile(r"\bactions/setup-python@")
+VERSION_FILE_RE = re.compile(
+    r"^\s*python-version-file:\s*['\"]?\.python-version['\"]?\s*(?:#.*)?$",
+    re.MULTILINE,
+)
+HARDCODED_VERSION_RE = re.compile(r"^\s*python-version:\s*", re.MULTILINE)
+
+version_lines = [line.strip() for line in PYTHON_VERSION.read_text(encoding="utf-8").splitlines() if line.strip()]
+if len(version_lines) != 1:
+    raise SystemExit(".python-version must contain exactly one non-empty version line")
+
+failures: list[str] = []
+checked_steps = 0
+
+for workflow in sorted((*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml"))):
+    text = workflow.read_text(encoding="utf-8")
+    setup_count = len(SETUP_PYTHON_RE.findall(text))
+    if not setup_count:
+        continue
+
+    checked_steps += setup_count
+    source_count = len(VERSION_FILE_RE.findall(text))
+    if source_count != setup_count:
+        failures.append(
+            f"{workflow}: {setup_count} setup-python step(s) but {source_count} .python-version source(s)"
+        )
+    if HARDCODED_VERSION_RE.search(text):
+        failures.append(f"{workflow}: hard-coded python-version found; use python-version-file instead")
+
+if not checked_steps:
+    raise SystemExit("No actions/setup-python steps found in GitHub Actions workflows")
+
+if failures:
+    print("Python runtime source drift detected:")
+    for failure in failures:
+        print(f"  - {failure}")
+    raise SystemExit(1)
+
+print(
+    f"Python runtime source aligned: {checked_steps} setup-python step(s) use "
+    f".python-version ({version_lines[0]})"
+)


### PR DESCRIPTION
## Summary
- add a deterministic check that every GitHub Actions `setup-python` step reads `.python-version`
- reject hard-coded `python-version:` entries in workflows
- run the check in post-optimization validation and document it in local validation

## Why
`.python-version` is now the single runtime source, but without a regression check a future workflow could silently reintroduce a hard-coded Python version and drift from the rest of the repository.

## Impact
No public portfolio content or behavior changes. This only strengthens maintenance reliability.