### PR TITLE
Guard GitHub Action dependency pins

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -89,6 +89,8 @@ jobs:
         run: python scripts/check_security_contact.py
       - name: Validate Python runtime source
         run: python scripts/check_python_runtime_alignment.py
+      - name: Validate GitHub Action pins
+        run: python scripts/check_github_action_pins.py
       - name: Validate documented local checks
         run: python scripts/check_validation_docs.py
       - name: Validate full interaction maintenance

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ python3.14 scripts/check_social_profile_derivation.py
 python3.14 scripts/check_llms_profile.py
 python3.14 scripts/check_year_filter_coverage.py
 python3.14 scripts/check_python_runtime_alignment.py
+python3.14 scripts/check_github_action_pins.py
 python3.14 scripts/check_validation_docs.py
 git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md llms.txt SECURITY.md .well-known/security.txt
 python3.14 scripts/maintain_static_fallbacks.py

--- a/scripts/check_github_action_pins.py
+++ b/scripts/check_github_action_pins.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(".github/workflows")
+USES_RE = re.compile(r"^\s*uses:\s*([^\s#]+)", re.MULTILINE)
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+problems: list[str] = []
+refs_by_action: dict[str, set[str]] = defaultdict(set)
+locations_by_action: dict[str, list[str]] = defaultdict(list)
+
+for pattern in ("*.yml", "*.yaml"):
+    for workflow in sorted(WORKFLOWS_DIR.glob(pattern)):
+        text = workflow.read_text(encoding="utf-8")
+        for match in USES_RE.finditer(text):
+            spec = match.group(1)
+            line_number = text.count("\n", 0, match.start()) + 1
+
+            if spec.startswith("./") or spec.startswith("docker://"):
+                continue
+
+            if "@" not in spec:
+                problems.append(f"{workflow}:{line_number}: action reference has no @ref: {spec}")
+                continue
+
+            action, ref = spec.rsplit("@", 1)
+            if not SHA_RE.fullmatch(ref):
+                problems.append(
+                    f"{workflow}:{line_number}: action is not pinned to a full commit SHA: {spec}"
+                )
+                continue
+
+            refs_by_action[action].add(ref.lower())
+            locations_by_action[action].append(f"{workflow}:{line_number}")
+
+for action, refs in sorted(refs_by_action.items()):
+    if len(refs) <= 1:
+        continue
+    problems.append(
+        f"{action}: inconsistent commit SHAs across workflows: {', '.join(sorted(refs))} "
+        f"({', '.join(locations_by_action[action])})"
+    )
+
+if problems:
+    print("GitHub Actions dependency pinning problems:")
+    for problem in problems:
+        print(f"  - {problem}")
+    raise SystemExit(1)
+
+print(
+    "GitHub Actions dependencies pinned consistently: "
+    f"{len(refs_by_action)} external actions across workflow files"
+)


### PR DESCRIPTION
## Summary

Add a deterministic check for GitHub Actions dependency references.

## Why

The repository already pins workflow actions to full commit SHAs, but nothing prevents a future workflow from using a mutable tag such as `@v7` or from drifting to a different SHA for the same action in one workflow.

This matters because:
- pinned commit SHAs reduce supply-chain risk from mutable action tags;
- one consistent SHA per action avoids silent workflow drift;
- the rule should be reproducible locally instead of living only as review convention.

## Changes

- add `scripts/check_github_action_pins.py`;
- reject external `uses:` references that lack a full 40-character commit SHA;
- reject inconsistent SHAs for the same action across workflow files;
- run the check in post-optimization validation;
- document the same check in README local validation.

Local and Docker actions are intentionally excluded from the external-action pin rule.