### PR TITLE
Guard GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -91,6 +91,8 @@ jobs:
         run: python scripts/check_python_runtime_alignment.py
       - name: Validate GitHub Action pins
         run: python scripts/check_github_action_pins.py
+      - name: Validate workflow permissions
+        run: python scripts/check_workflow_permissions.py
       - name: Validate documented local checks
         run: python scripts/check_validation_docs.py
       - name: Validate full interaction maintenance

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ python3.14 scripts/check_llms_profile.py
 python3.14 scripts/check_year_filter_coverage.py
 python3.14 scripts/check_python_runtime_alignment.py
 python3.14 scripts/check_github_action_pins.py
+python3.14 scripts/check_workflow_permissions.py
 python3.14 scripts/check_validation_docs.py
 git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md llms.txt SECURITY.md .well-known/security.txt
 python3.14 scripts/maintain_static_fallbacks.py

--- a/scripts/check_workflow_permissions.py
+++ b/scripts/check_workflow_permissions.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(".github/workflows")
+WRITE_ALLOWED = {Path(".github/workflows/optimize-portfolio.yml")}
+TOP_LEVEL_PERMISSIONS_RE = re.compile(
+    r"(?m)^permissions:\s*\n((?:^[ \t]+[^\n]+\n?)*)"
+)
+CONTENTS_PERMISSION_RE = re.compile(r"(?m)^  contents:\s*(read|write)\s*$")
+
+
+def workflow_paths() -> list[Path]:
+    paths: list[Path] = []
+    for pattern in ("*.yml", "*.yaml"):
+        paths.extend(WORKFLOWS_DIR.glob(pattern))
+    return sorted(paths)
+
+
+errors: list[str] = []
+paths = workflow_paths()
+
+if not paths:
+    raise SystemExit("No GitHub Actions workflows found")
+
+for path in paths:
+    text = path.read_text(encoding="utf-8")
+    match = TOP_LEVEL_PERMISSIONS_RE.search(text)
+    if not match:
+        errors.append(f"{path}: missing explicit top-level permissions block")
+        continue
+
+    contents_match = CONTENTS_PERMISSION_RE.search(match.group(1))
+    if not contents_match:
+        errors.append(f"{path}: top-level permissions must declare contents: read or write")
+        continue
+
+    permission = contents_match.group(1)
+    if permission == "write" and path not in WRITE_ALLOWED:
+        errors.append(f"{path}: unexpected contents: write permission")
+    if permission == "read" and path in WRITE_ALLOWED:
+        errors.append(f"{path}: optimizer workflow requires contents: write to commit maintained assets")
+
+    extra_scopes = [
+        line.strip()
+        for line in match.group(1).splitlines()
+        if line.strip() and not line.startswith("  contents:")
+    ]
+    if extra_scopes:
+        errors.append(
+            f"{path}: unexpected top-level permission scopes: {', '.join(extra_scopes)}"
+        )
+
+if errors:
+    print("GitHub Actions workflow permission policy violations:")
+    for error in errors:
+        print(f"  - {error}")
+    raise SystemExit(1)
+
+print(
+    "Workflow permissions aligned: "
+    f"{len(paths)} workflows declare explicit least-privilege contents access; "
+    f"write access limited to {', '.join(str(path) for path in sorted(WRITE_ALLOWED))}"
+)


### PR DESCRIPTION
## Summary

Add a deterministic check that every GitHub Actions workflow declares explicit top-level `permissions` and that repository write access stays limited to the portfolio optimization workflow.

## Why

The current workflows already follow least privilege, but that policy was not enforced. A future workflow could omit `permissions` and inherit broader defaults, or accidentally add `contents: write` to a validation-only job without any regression check noticing.

## Changes

- add `scripts/check_workflow_permissions.py`
- require every workflow to declare explicit `contents: read` or `contents: write`
- allow `contents: write` only for `.github/workflows/optimize-portfolio.yml`
- reject unexpected additional top-level permission scopes
- run the check in post-optimization validation
- document the same command in local validation

No portfolio content or visual behavior changes.