### PR TITLE
Cancel stale validation workflow runs

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -41,6 +41,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-links:
     runs-on: ubuntu-latest

--- a/.github/workflows/progressive-enhancement.yml
+++ b/.github/workflows/progressive-enhancement.yml
@@ -27,6 +27,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ensure-static-content-visible:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-contact-check.yml
+++ b/.github/workflows/security-contact-check.yml
@@ -27,6 +27,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/site-integrity.yml
+++ b/.github/workflows/site-integrity.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/structured-profile.yml
+++ b/.github/workflows/structured-profile.yml
@@ -40,6 +40,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tab-maintenance-check.yml
+++ b/.github/workflows/tab-maintenance-check.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add branch-scoped GitHub Actions concurrency to the seven validation workflows that still allowed older runs to continue after a newer run started for the same ref.

## Why

Rapid maintenance pushes can queue duplicate validation for the same branch or pull request. The older result is no longer useful once a newer commit exists, but it still consumes runner time and can delay the result that matters.

## Change

- use `${{ github.workflow }}-${{ github.ref }}` as the concurrency group
- enable `cancel-in-progress: true`
- keep the existing optimizer and static-fallback concurrency behavior unchanged
- make no portfolio content or visual changes

This keeps validation isolated by workflow and ref, so unrelated branches and pull requests do not cancel each other.