### PR TITLE
Guard GitHub Actions job timeouts

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -97,6 +97,8 @@ jobs:
         run: python scripts/check_github_action_pins.py
       - name: Validate workflow permissions
         run: python scripts/check_workflow_permissions.py
+      - name: Validate workflow timeout policy
+        run: python scripts/check_workflow_timeouts.py
       - name: Validate documented local checks
         run: python scripts/check_validation_docs.py
       - name: Validate full interaction maintenance

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ node --check main.js
 "$PYTHON" scripts/check_python_runtime_alignment.py
 "$PYTHON" scripts/check_github_action_pins.py
 "$PYTHON" scripts/check_workflow_permissions.py
+"$PYTHON" scripts/check_workflow_timeouts.py
 "$PYTHON" scripts/check_validation_docs.py
 git diff --exit-code -- index.html 404.html main.js style.css sitemap.xml README.md llms.txt SECURITY.md .well-known/security.txt
 "$PYTHON" scripts/maintain_static_fallbacks.py

--- a/scripts/check_workflow_timeouts.py
+++ b/scripts/check_workflow_timeouts.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(".github/workflows")
+MAX_TIMEOUT_MINUTES = 30
+JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+TIMEOUT_RE = re.compile(r"^    timeout-minutes:\s*(\d+)\s*(?:#.*)?$")
+
+
+def workflow_jobs(text: str) -> list[tuple[str, list[str]]]:
+    lines = text.splitlines()
+    try:
+        jobs_start = next(i for i, line in enumerate(lines) if line == "jobs:")
+    except StopIteration:
+        return []
+
+    jobs: list[tuple[str, list[str]]] = []
+    current_name: str | None = None
+    current_lines: list[str] = []
+
+    for line in lines[jobs_start + 1 :]:
+        if line and not line.startswith(" "):
+            break
+
+        match = JOB_RE.match(line)
+        if match:
+            if current_name is not None:
+                jobs.append((current_name, current_lines))
+            current_name = match.group(1)
+            current_lines = []
+        elif current_name is not None:
+            current_lines.append(line)
+
+    if current_name is not None:
+        jobs.append((current_name, current_lines))
+    return jobs
+
+
+problems: list[str] = []
+runner_jobs = 0
+
+for pattern in ("*.yml", "*.yaml"):
+    for workflow in sorted(WORKFLOWS_DIR.glob(pattern)):
+        text = workflow.read_text(encoding="utf-8")
+        for job_name, job_lines in workflow_jobs(text):
+            if not any(re.match(r"^    runs-on:\s*\S+", line) for line in job_lines):
+                continue
+
+            runner_jobs += 1
+            timeout_values = [
+                int(match.group(1))
+                for line in job_lines
+                if (match := TIMEOUT_RE.match(line))
+            ]
+
+            if len(timeout_values) != 1:
+                problems.append(
+                    f"{workflow}:{job_name}: expected exactly one numeric timeout-minutes value"
+                )
+                continue
+
+            timeout = timeout_values[0]
+            if not 1 <= timeout <= MAX_TIMEOUT_MINUTES:
+                problems.append(
+                    f"{workflow}:{job_name}: timeout-minutes must be between 1 and "
+                    f"{MAX_TIMEOUT_MINUTES}, found {timeout}"
+                )
+
+if runner_jobs == 0:
+    problems.append("No runner-backed workflow jobs found")
+
+if problems:
+    print("Workflow timeout policy violations:")
+    for problem in problems:
+        print(f"  - {problem}")
+    raise SystemExit(1)
+
+print(
+    f"Workflow timeout policy valid: {runner_jobs} runner-backed job(s), "
+    f"all capped at {MAX_TIMEOUT_MINUTES} minutes or less"
+)


### PR DESCRIPTION
## What changed

- add `scripts/check_workflow_timeouts.py`
- require every runner-backed GitHub Actions job to declare one numeric `timeout-minutes`
- cap accepted job timeouts at 30 minutes
- run the check in post-optimization validation
- document the same check in local validation

## Why

All current workflow jobs already have sensible timeouts, but that policy was only implicit. A future job could omit `timeout-minutes` and hang until GitHub's much larger default limit. This turns the existing convention into a regression check without changing the portfolio UI.

## Perspectives

- **Researcher:** no public content changes; keeps publication/profile validation from being delayed by a stuck CI job.
- **Recruiter:** no visible changes; preserves reliable deployment checks for the portfolio and CV links.
- **Engineer:** makes bounded CI execution an enforced repository rule rather than a convention.