### PR TITLE
Keep organization badge alt text meaningful after sync

### DIFF
--- a/assets/data.json
+++ b/assets/data.json
@@ -66,15 +66,15 @@
     ],
     "badges-orgs": [
       {
-        "alt": "GitHub画像",
+        "alt": "RM-NAGOYASHACHIHOKO",
         "src": "https://github.com/user-attachments/assets/06029876-4a7b-44fe-8df6-cac6bbbf8391"
       },
       {
-        "alt": "GitHub画像",
+        "alt": "JPHacks",
         "src": "https://github.com/user-attachments/assets/3df7dbab-02ff-494d-b468-3bf755043a2c"
       },
       {
-        "alt": "GitHub画像",
+        "alt": "Jogiken",
         "src": "https://github.com/user-attachments/assets/7109b8d7-da71-4b8d-8858-773980b358d5"
       }
     ]

--- a/scripts/sync_readme_assets.py
+++ b/scripts/sync_readme_assets.py
@@ -62,9 +62,16 @@ def normalize_organization_alts(items: list[dict[str, str]]) -> list[dict[str, s
     for item in items:
         alt = item.get("alt", "").strip()
         src = item.get("src", "").strip()
+        if alt and alt not in GENERIC_ORGANIZATION_ALTS:
+            continue
+
         replacement = ORGANIZATION_ALT_BY_SRC.get(src)
-        if replacement and (not alt or alt in GENERIC_ORGANIZATION_ALTS):
-            item["alt"] = replacement
+        if not replacement:
+            raise SystemExit(
+                "Organization badge has generic alt text with an unknown image source: "
+                f"{src!r}"
+            )
+        item["alt"] = replacement
     return items
 
 

--- a/scripts/sync_readme_assets.py
+++ b/scripts/sync_readme_assets.py
@@ -19,6 +19,13 @@ THUMB_DIR = ASSETS_DIR / "thumbnails"
 DATA_FILE = ASSETS_DIR / "data.json"
 INDEX_FILE = ROOT / "index.html"
 
+ORGANIZATION_ALT_BY_SRC = {
+    "https://github.com/user-attachments/assets/06029876-4a7b-44fe-8df6-cac6bbbf8391": "RM-NAGOYASHACHIHOKO",
+    "https://github.com/user-attachments/assets/3df7dbab-02ff-494d-b468-3bf755043a2c": "JPHacks",
+    "https://github.com/user-attachments/assets/7109b8d7-da71-4b8d-8858-773980b358d5": "Jogiken",
+}
+GENERIC_ORGANIZATION_ALTS = {"GitHub画像"}
+
 
 def extract_images(content: str, header_pattern: str) -> list[dict[str, str]]:
     pattern = re.compile(
@@ -48,6 +55,17 @@ def extract_images(content: str, header_pattern: str) -> list[dict[str, str]]:
                 }
             )
     return images
+
+
+def normalize_organization_alts(items: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Replace generic source README labels with stable organization names."""
+    for item in items:
+        alt = item.get("alt", "").strip()
+        src = item.get("src", "").strip()
+        replacement = ORGANIZATION_ALT_BY_SRC.get(src)
+        if replacement and (not alt or alt in GENERIC_ORGANIZATION_ALTS):
+            item["alt"] = replacement
+    return items
 
 
 def sync_app_thumbnail(full_repo: str, img_src: str) -> str:
@@ -130,7 +148,9 @@ def main() -> None:
     data["badges"]["badges-frameworks"] = extract_images(
         content, r"Frameworks|Tools|ツール|技術"
     )
-    data["badges"]["badges-orgs"] = extract_images(content, r"Organizations|所属")
+    data["badges"]["badges-orgs"] = normalize_organization_alts(
+        extract_images(content, r"Organizations|所属")
+    )
 
     apps_match = re.search(
         r"^##\s+My Apps\s*$([\s\S]*?)(?=^##\s|\Z)",


### PR DESCRIPTION
## Summary
- normalize generic organization badge alt text from the profile README to stable organization names
- regenerate `assets/data.json` with meaningful labels
- fail synchronization if a new organization image uses generic alt text without an explicit mapping

## Why
The profile README currently labels all organization images as `GitHub画像`. Updating only the generated portfolio data is temporary because `sync_readme_assets.py` restores those generic labels on the next sync. This change fixes the source of the regression and makes future unmapped organization badges fail visibly instead of silently degrading accessibility.

## Impact
- Researcher/recruiter: organization images keep useful accessible names
- Engineer: generated metadata no longer regresses after asset synchronization